### PR TITLE
fix trivy scan

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -16,6 +16,9 @@ jobs:
     name: Scan
     runs-on: "ubuntu-18.04"
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.6.1
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

add checkout before fs scan

**Release note**:
```release-note
NONE
```
