### PR TITLE
update to go 1.19

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "^1.19"
 
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "^1.19"
 
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "^1.19"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
-
+      - "v*"
 
 jobs:
   goreleaser:
@@ -29,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: "^1.19"
 
       - name: Describe plugin
         id: plugin_describe

--- a/.github/workflows/synopsys-schedule.yaml
+++ b/.github/workflows/synopsys-schedule.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "^1.17"
+          go-version: "^1.19"
 
       - name: Build Project
         run: make build


### PR DESCRIPTION

**What this PR does / why we need it**:

update workflow to use golang 1.19

**Release note**:
```release-note
NONE
```
