### PR TITLE
Increased timeout for IP assignment to 15 minutes.

### DIFF
--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -457,8 +457,10 @@ func (d *NutanixDriver) Create(req *v3.VMIntentInput) (*nutanixInstance, error) 
 		}
 	}
 
-	// Wait for the VM obtain an IP address
-	for i := 0; i < 60; i++ {
+	// Wait for the VM obtain an IP address.
+	//
+	// Timeout is 180*5s, or equal to 15 minutes.
+	for i := 0; i < 180; i++ {
 		vm, err = conn.V3.GetVM(uuid)
 		if err != nil || len(vm.Status.Resources.NicList[0].IPEndpointList) == (0) {
 			log.Printf("Waiting VM (%s) ip configuration", uuid)


### PR DESCRIPTION
**What this PR does / why we need it**:

* Windows requires more than a 5 minute timeout for IP assignment, so the default timeout has been increased to 15 minutes. The delay between attempts remains 5 seconds for performance, however the attempts are increased to 180.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

* Fixes #82

**How Has This Been Tested?**:

* No testing performed.

**Release note**:

```
The timeout for IP assignment has been increased to 15 minutes.
```
