### PR TITLE
implement delete and force source_image option

### DIFF
--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -59,11 +59,13 @@ type ClusterConfig struct {
 }
 
 type VmDisk struct {
-	ImageType       string `mapstructure:"image_type" json:"image_type" required:"false"`
-	SourceImageName string `mapstructure:"source_image_name" json:"source_image_name" required:"false"`
-	SourceImageUUID string `mapstructure:"source_image_uuid" json:"source_image_uuid" required:"false"`
-	SourceImageURI  string `mapstructure:"source_image_uri" json:"source_image_uri" required:"false"`
-	DiskSizeGB      int64  `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false"`
+	ImageType         string `mapstructure:"image_type" json:"image_type" required:"false"`
+	SourceImageName   string `mapstructure:"source_image_name" json:"source_image_name" required:"false"`
+	SourceImageUUID   string `mapstructure:"source_image_uuid" json:"source_image_uuid" required:"false"`
+	SourceImageURI    string `mapstructure:"source_image_uri" json:"source_image_uri" required:"false"`
+	SourceImageDelete bool   `mapstructure:"source_image_delete" json:"source_image_delete" required:"false"`
+	SourceImageForce  bool   `mapstructure:"source_image_force" json:"source_image_force" required:"false"`
+	DiskSizeGB        int64  `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false"`
 }
 
 type VmNIC struct {

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -308,11 +308,13 @@ func (*FlatVmConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatVmDisk is an auto-generated flat version of VmDisk.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatVmDisk struct {
-	ImageType       *string `mapstructure:"image_type" json:"image_type" required:"false" cty:"image_type" hcl:"image_type"`
-	SourceImageName *string `mapstructure:"source_image_name" json:"source_image_name" required:"false" cty:"source_image_name" hcl:"source_image_name"`
-	SourceImageUUID *string `mapstructure:"source_image_uuid" json:"source_image_uuid" required:"false" cty:"source_image_uuid" hcl:"source_image_uuid"`
-	SourceImageURI  *string `mapstructure:"source_image_uri" json:"source_image_uri" required:"false" cty:"source_image_uri" hcl:"source_image_uri"`
-	DiskSizeGB      *int64  `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false" cty:"disk_size_gb" hcl:"disk_size_gb"`
+	ImageType         *string `mapstructure:"image_type" json:"image_type" required:"false" cty:"image_type" hcl:"image_type"`
+	SourceImageName   *string `mapstructure:"source_image_name" json:"source_image_name" required:"false" cty:"source_image_name" hcl:"source_image_name"`
+	SourceImageUUID   *string `mapstructure:"source_image_uuid" json:"source_image_uuid" required:"false" cty:"source_image_uuid" hcl:"source_image_uuid"`
+	SourceImageURI    *string `mapstructure:"source_image_uri" json:"source_image_uri" required:"false" cty:"source_image_uri" hcl:"source_image_uri"`
+	SourceImageDelete *bool   `mapstructure:"source_image_delete" json:"source_image_delete" required:"false" cty:"source_image_delete" hcl:"source_image_delete"`
+	SourceImageForce  *bool   `mapstructure:"source_image_force" json:"source_image_force" required:"false" cty:"source_image_force" hcl:"source_image_force"`
+	DiskSizeGB        *int64  `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false" cty:"disk_size_gb" hcl:"disk_size_gb"`
 }
 
 // FlatMapstructure returns a new FlatVmDisk.
@@ -327,11 +329,13 @@ func (*VmDisk) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec }
 // The decoded values from this spec will then be applied to a FlatVmDisk.
 func (*FlatVmDisk) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"image_type":        &hcldec.AttrSpec{Name: "image_type", Type: cty.String, Required: false},
-		"source_image_name": &hcldec.AttrSpec{Name: "source_image_name", Type: cty.String, Required: false},
-		"source_image_uuid": &hcldec.AttrSpec{Name: "source_image_uuid", Type: cty.String, Required: false},
-		"source_image_uri":  &hcldec.AttrSpec{Name: "source_image_uri", Type: cty.String, Required: false},
-		"disk_size_gb":      &hcldec.AttrSpec{Name: "disk_size_gb", Type: cty.Number, Required: false},
+		"image_type":          &hcldec.AttrSpec{Name: "image_type", Type: cty.String, Required: false},
+		"source_image_name":   &hcldec.AttrSpec{Name: "source_image_name", Type: cty.String, Required: false},
+		"source_image_uuid":   &hcldec.AttrSpec{Name: "source_image_uuid", Type: cty.String, Required: false},
+		"source_image_uri":    &hcldec.AttrSpec{Name: "source_image_uri", Type: cty.String, Required: false},
+		"source_image_delete": &hcldec.AttrSpec{Name: "source_image_delete", Type: cty.Bool, Required: false},
+		"source_image_force":  &hcldec.AttrSpec{Name: "source_image_force", Type: cty.Bool, Required: false},
+		"disk_size_gb":        &hcldec.AttrSpec{Name: "disk_size_gb", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/nutanix/step_build_vm.go
+++ b/builder/nutanix/step_build_vm.go
@@ -26,7 +26,7 @@ func (s *stepBuildVM) Run(ctx context.Context, state multistep.StateBag) multist
 		ui.Say("Uploading CD disk...")
 		cdFilesPath := cdPathRaw.(string)
 		log.Println("CD disk found " + cdFilesPath)
-		cdfilesImage, err := d.UploadImage(cdFilesPath, "PATH", "ISO_IMAGE", config.VmConfig)
+		cdfilesImage, err := d.CreateImageFile(cdFilesPath, config.VmConfig)
 		if err != nil {
 			ui.Error("Error uploading CD disk:" + err.Error())
 			state.Put("error", err)
@@ -46,7 +46,7 @@ func (s *stepBuildVM) Run(ctx context.Context, state multistep.StateBag) multist
 	ui.Say("Creating Packer Builder virtual machine...")
 
 	// Create VM Spec
-	vmRequest, err := d.CreateRequest(config.VmConfig)
+	vmRequest, err := d.CreateRequest(config.VmConfig, state)
 	if err != nil {
 		ui.Error("Error creating virtual machine request: " + err.Error())
 		state.Put("error", err)
@@ -111,6 +111,13 @@ func (s *stepBuildVM) Cleanup(state multistep.StateBag) {
 		return
 	} else {
 		ui.Message("Virtual machine successfully deleted")
+	}
+
+	imageToDelete := state.Get("image_to_delete")
+
+	for _, image := range imageToDelete.([]string) {
+		log.Printf("delete marked image: %s", image)
+		d.DeleteImage(image)
 	}
 
 }

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -90,6 +90,8 @@ Sample:
 - `source_image_name` (string) - Name of the image used as disk source.
 - `source_image_uuid` (string) - UUID of the image used as disk source.
 - `source_image_uri` (string) - URI of the image used as disk source (if image is not already on the cluster, it will download and store it before launching output image creation process).
+- `source_image_delete` (bool) - Delete source image once build process is completed (default is false).
+- `source_image_force` (bool) - Always download and replace source image even if already exist (default is false).
 - `disk_size_gb` (number) - size of the disk (in gigabytes).
 
 Sample:
@@ -104,6 +106,8 @@ Sample:
 - `image_type` (string) - "ISO_IMAGE".
 - `source_image_name` (string) - Name of the ISO image to mount.
 - `source_image_uuid` (string) - UUID of the ISO image to mount.
+- `source_image_delete` (bool) - Delete source image once build process is completed (default is false).
+- `source_image_force` (bool) - Always download and replace source image even if already exist (default is false).
 
 Sample:
 ```hcl


### PR DESCRIPTION
**What this PR does / why we need it**:

implement additional option for unitary management of each source_image

`source_image_delete`: allow to delete a downloaded image once build process is finished
`source_image_force`: allow to redownload a source_image even if they already exist in the library

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #136 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
- implement delete and force source_image option
```
