### PR TITLE
Makefile: make dev uses packer for install

### DIFF
--- a/.github/workflows/test-plugin-e2e.yaml
+++ b/.github/workflows/test-plugin-e2e.yaml
@@ -27,12 +27,12 @@ jobs:
       - name: Build packer plugin
         run: |
           cd $GITHUB_WORKSPACE
-          make dev
+          make build
 
       - uses: actions/upload-artifact@v4
         with:
           name: packer-plugin-nutanix
-          path: ~/.config/packer/plugins/packer-plugin-nutanix
+          path: packer-plugin-nutanix
           retention-days: 7
 
       - name: build test list
@@ -70,11 +70,13 @@ jobs:
           name: packer-plugin-nutanix
           path: /tmp
 
+      - name: Fix plugin permissions
+        run: |
+          chmod +x /tmp/packer-plugin-nutanix
+
       - name: Install plugin
         run: |
-          mkdir -p ~/.config/packer/plugins/
-          cp /tmp/packer-plugin-nutanix ~/.config/packer/plugins/packer-plugin-nutanix
-          chmod 755 ~/.config/packer/plugins/packer-plugin-nutanix
+          packer plugins install --path /tmp/packer-plugin-nutanix "github.com/nutanix-cloud-native/nutanix"
 
       - name: Run `packer init`
         id: init

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 NAME=nutanix
 BINARY=packer-plugin-${NAME}
+PLUGIN_FQN="$(shell grep -E '^module' <go.mod | sed -E 's/module *//')"
 
 COUNT?=1
 TEST?=$(shell go list ./...)
@@ -10,9 +11,9 @@ HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/pac
 build:
 	@go build -o ${BINARY}
 
-dev: build
-	@mkdir -p ~/.config/packer/plugins
-	@mv ${BINARY} ~/.config/packer/plugins/${BINARY}
+dev:
+	@go build -ldflags="-X '${PLUGIN_FQN}/version.VersionPrerelease=dev'" -o '${BINARY}'
+	packer plugins install --path ${BINARY} "$(shell echo "${PLUGIN_FQN}" | sed 's/packer-plugin-//')"
 
 test:
 	@go test -race -count $(COUNT) $(TEST) -timeout=3m


### PR DESCRIPTION
When building the development version of the plugin, we now use
`packer plugins install` for that instead of moving it to the plugins
directory manually.

This target will require Packer 1.10.2 and above to function, as prior
versions don't support instaling pre-release versions of a plugin with
that command.
