### PR TITLE
feat: adds GPU support to packer plugin nutanix

### DIFF
--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -1,4 +1,4 @@
-//go:generate packer-sdc mapstructure-to-hcl2 -type Config,Category,ClusterConfig,VmConfig,VmDisk,VmNIC
+//go:generate packer-sdc mapstructure-to-hcl2 -type Config,Category,ClusterConfig,VmConfig,VmDisk,VmNIC,GPU
 
 package nutanix
 
@@ -45,6 +45,10 @@ type Config struct {
 	ctx interpolate.Context
 }
 
+type GPU struct {
+	Name string `mapstructure:"name" json:"name" required:"false"`
+}
+
 type Category struct {
 	Key   string `mapstructure:"key" json:"key" required:"false"`
 	Value string `mapstructure:"value" json:"value" required:"false"`
@@ -86,6 +90,7 @@ type VmConfig struct {
 	UserData     string     `mapstructure:"user_data" json:"user_data" required:"false"`
 	VMCategories []Category `mapstructure:"vm_categories" required:"false"`
 	Project      string     `mapstructure:"project" required:"false"`
+	GPU          []GPU      `mapstructure:"gpu" required:"false"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -146,6 +146,7 @@ type FlatConfig struct {
 	UserData                  *string           `mapstructure:"user_data" json:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	VMCategories              []FlatCategory    `mapstructure:"vm_categories" required:"false" cty:"vm_categories" hcl:"vm_categories"`
 	Project                   *string           `mapstructure:"project" required:"false" cty:"project" hcl:"project"`
+	GPU                       []FlatGPU         `mapstructure:"gpu" required:"false" cty:"gpu" hcl:"gpu"`
 	ForceDeregister           *bool             `mapstructure:"force_deregister" json:"force_deregister" required:"false" cty:"force_deregister" hcl:"force_deregister"`
 	ImageDescription          *string           `mapstructure:"image_description" json:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageCategories           []FlatCategory    `mapstructure:"image_categories" required:"false" cty:"image_categories" hcl:"image_categories"`
@@ -247,6 +248,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"vm_categories":                &hcldec.BlockListSpec{TypeName: "vm_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
 		"project":                      &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
+		"gpu":                          &hcldec.BlockListSpec{TypeName: "gpu", Nested: hcldec.ObjectSpec((*FlatGPU)(nil).HCL2Spec())},
 		"force_deregister":             &hcldec.AttrSpec{Name: "force_deregister", Type: cty.Bool, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_categories":             &hcldec.BlockListSpec{TypeName: "image_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
@@ -254,6 +256,29 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_export":                 &hcldec.AttrSpec{Name: "image_export", Type: cty.Bool, Required: false},
 		"ip_wait_timeout":              &hcldec.AttrSpec{Name: "ip_wait_timeout", Type: cty.String, Required: false},
 		"vm_force_delete":              &hcldec.AttrSpec{Name: "vm_force_delete", Type: cty.Bool, Required: false},
+	}
+	return s
+}
+
+// FlatGPU is an auto-generated flat version of GPU.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatGPU struct {
+	Name *string `mapstructure:"name" json:"name" required:"false" cty:"name" hcl:"name"`
+}
+
+// FlatMapstructure returns a new FlatGPU.
+// FlatGPU is an auto-generated flat version of GPU.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*GPU) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatGPU)
+}
+
+// HCL2Spec returns the hcl spec of a GPU.
+// This spec is used by HCL to read the fields of GPU.
+// The decoded values from this spec will then be applied to a FlatGPU.
+func (*FlatGPU) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"name": &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
 	}
 	return s
 }
@@ -274,6 +299,7 @@ type FlatVmConfig struct {
 	UserData     *string        `mapstructure:"user_data" json:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	VMCategories []FlatCategory `mapstructure:"vm_categories" required:"false" cty:"vm_categories" hcl:"vm_categories"`
 	Project      *string        `mapstructure:"project" required:"false" cty:"project" hcl:"project"`
+	GPU          []FlatGPU      `mapstructure:"gpu" required:"false" cty:"gpu" hcl:"gpu"`
 }
 
 // FlatMapstructure returns a new FlatVmConfig.
@@ -301,6 +327,7 @@ func (*FlatVmConfig) HCL2Spec() map[string]hcldec.Spec {
 		"user_data":     &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"vm_categories": &hcldec.BlockListSpec{TypeName: "vm_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
 		"project":       &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
+		"gpu":           &hcldec.BlockListSpec{TypeName: "gpu", Nested: hcldec.ObjectSpec((*FlatGPU)(nil).HCL2Spec())},
 	}
 	return s
 }

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -34,7 +34,7 @@ These parameters allow to define information about platform and temporary VM use
   - `ip_wait_timeout` (duration string | ex: "0h42m0s") - Amount of time to wait for VM's IP, similar to 'ssh_timeout'. Defaults to 15m (15 minutes). See the Golang [ParseDuration](https://golang.org/pkg/time/#ParseDuration) documentation for full details.
   - `vm_categories` ([]Category) - Assign Categories to the vm.
   - `project` (string) - Assign Project to the vm.
-  
+  - `gpu` ([] GPU) - GPU in cluster name to be attached on temporary VM.
 
 
 ## Output configuration
@@ -152,6 +152,18 @@ Sample
 ```
 
 Note: Categories must already be present in Prism Central.
+
+## GPU Configuration
+
+Use `GPU` to assign a GPU that is present on `cluster-name` on the temporary vm. Add the name of the GPU you wish to attach.
+
+Sample
+
+```hcl
+  gpu {
+    name = "Ampere 40"
+  }
+```
 
 ## Samples
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/packer-plugin-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Adds GPU support to the packer plugin.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #123 

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_

I tested this by adding this to my packer.pkl.hcl file 

```hcl
source "nutanix" "kib_image" {
  boot_type              = var.boot_type
  cluster_name           = trim(var.nutanix_cluster_name, "\r\n")
  cpu                    = var.cpus
  force_deregister       = var.force_deregister
  gpu {
    name = "Ampere 40"
  }
  image_delete           = local.image_delete
  image_description      = "kube image-builder packer"
  image_export           = var.image_export
  image_name             = local.image_name
  memory_mb              = var.memory
  nutanix_endpoint       = trim(var.nutanix_endpoint, "\r\n")
  nutanix_insecure       = trim(var.nutanix_insecure, "\r\n")
  nutanix_password       = trim(var.nutanix_password, "\r\n")
  nutanix_port           = trim(var.nutanix_port, "\r\n")
  nutanix_username       = trim(var.nutanix_username, "\r\n")
  os_type                = var.guest_os_type
  shutdown_command       = "echo '${var.ssh_password}' | sudo -S -E sh -c 'usermod -L ${var.ssh_username} && ${var.shutdown_command}'"
  ssh_handshake_attempts = "100"
  ssh_agent_auth         = var.ssh_agent_auth
  ssh_private_key_file   = local.ssh_private_key_file
  ssh_password           = var.ssh_password
  ssh_timeout            = "20m"
  ssh_username           = var.ssh_username
  user_data              = base64encode(local.cloud_init)
  vm_disks {
    disk_size_gb        = var.disk_size_gb
    image_type          = "DISK_IMAGE"
    source_image_delete = var.source_image_delete
    source_image_force  = var.source_image_force
    source_image_uri    = var.source_image_url
    source_image_name   = var.source_image_name
  }
  vm_force_delete        = var.vm_force_delete
  vm_name                = local.image_name
  vm_nics  {
    subnet_name = trim(var.nutanix_subnet_name,  "\r\n")
  }
}
```

This created the VM and when I observed in the console the GPU was attached 

```sh
12:10 PM  faiqus @ archlinux  ~/go/src/github.com/nutanix-cloud-native/example   
$ packer build -debug -var-file=./rocky.pkrvars.hcl packer.pkr.hcl 
Debug mode enabled. Builds will not be parallelized.
nutanix.kib_image: output will be in this color.

==> nutanix.kib_image: Creating Packer Builder virtual machine...
    nutanix.kib_image: Virtual machine rocky-9.3-kube--20240502181338 created
    nutanix.kib_image: Found IP for virtual machine: 10.41.16.5
==> nutanix.kib_image: Using SSH communicator to connect: 10.41.16.5
==> nutanix.kib_image: Waiting for SSH to become available...
==> nutanix.kib_image: Connected to SSH!
==> nutanix.kib_image: Gracefully halting virtual machine...
==> nutanix.kib_image: Creating image(s) from virtual machine rocky-9.3-kube--20240502181338...
    nutanix.kib_image: Found disk to copy: SCSI:0
    nutanix.kib_image: Image successfully created: rocky-9.3-kube--20240502181338 (df466e42-8940-43a7-822a-60e216be3df1)
==> nutanix.kib_image: Deleting virtual machine...
    nutanix.kib_image: Virtual machine successfully deleted
==> nutanix.kib_image: Running post-processor: packer-manifest (type manifest)
Build 'nutanix.kib_image' finished after 1 minute 23 seconds.

==> Wait completed after 1 minute 23 seconds

==> Builds finished. The artifacts of successful builds are:
--> nutanix.kib_image: rocky-9.3-kube--20240502181338
--> nutanix.kib_image: rocky-9.3-kube--20240502181338
```

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds GPU support to plugin
```
