### PR TITLE
fix: panic during power off

### DIFF
--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -930,7 +930,9 @@ func (d *NutanixDriver) PowerOff(vmUUID string) error {
 			<-time.After(1 * time.Second)
 			continue
 		}
-		return fmt.Errorf("error while GetTask, %s", err.Error())
+		if err != nil {
+			return fmt.Errorf("error while GetTask, %s", err.Error())
+		}
 	}
 
 	log.Printf("PowerOff task: %s", taskUUID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/packer-plugin-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

fixes a panic when error is not present.

```
2024/06/05 21:12:20 ui error: ==> nutanix.bastion_image: Created symlink /etc/systemd/system/multi-user.target.wants/docker.service → /usr/lib/systemd/system/docker.service.
2024/06/05 21:12:22 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 2024/06/05 21:12:22 [INFO] RPC endpoint: Communicator ended with: 0
2024/06/05 21:12:22 [INFO] 152124 bytes written for 'stdout'
2024/06/05 21:12:22 [INFO] 532 bytes written for 'stderr'
2024/06/05 21:12:22 [INFO] RPC client: Communicator ended with: 0
2024/06/05 21:12:22 [INFO] RPC endpoint: Communicator ended with: 0
2024/06/05 21:12:22 packer-provisioner-shell plugin: [INFO] 152124 bytes written for 'stdout'
2024/06/05 21:12:22 packer-provisioner-shell plugin: [INFO] 532 bytes written for 'stderr'
2024/06/05 21:12:22 packer-provisioner-shell plugin: [INFO] RPC client: Communicator ended with: 0
2024/06/05 21:12:22 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 2024/06/05 21:12:22 [DEBUG] Opening new ssh session
2024/06/05 21:12:22 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 2024/06/05 21:12:22 [DEBUG] starting remote command: rm -f /tmp/script_2584.sh
2024/06/05 21:12:23 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 2024/06/05 21:12:23 [INFO] RPC endpoint: Communicator ended with: 0
2024/06/05 21:12:23 [INFO] RPC client: Communicator ended with: 0
2024/06/05 21:12:23 [INFO] RPC endpoint: Communicator ended with: 0
2024/06/05 21:12:23 packer-provisioner-shell plugin: [INFO] RPC client: Communicator ended with: 0
2024/06/05 21:12:23 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 2024/06/05 21:12:23 [DEBUG] Opening new ssh session
2024/06/05 21:12:23 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 2024/06/05 21:12:23 [DEBUG] starting remote command: rm -f
2024/06/05 21:12:23 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 2024/06/05 21:12:23 [INFO] RPC endpoint: Communicator ended with: 0
2024/06/05 21:12:23 [INFO] RPC client: Communicator ended with: 0
2024/06/05 21:12:23 [INFO] RPC endpoint: Communicator ended with: 0
2024/06/05 21:12:23 packer-provisioner-shell plugin: [INFO] RPC client: Communicator ended with: 0
2024/06/05 21:12:23 [INFO] (telemetry) ending shell
2024/06/05 21:12:23 ui: ==> nutanix.bastion_image: Halting the virtual machine...
2024/06/05 21:12:30 ui: ==> nutanix.bastion_image: Deleting virtual machine...
2024/06/05 21:12:30 ui:     nutanix.bastion_image: Virtual machine successfully deleted
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: panic: runtime error: invalid memory address or nil pointer dereference
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xee9e79]
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: goroutine 24 [running]:
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: github.com/nutanix-cloud-native/packer-plugin-nutanix/builder/nutanix.(*NutanixDriver).PowerOff(0xc00070e008, {0xc0006f64b0, 0x24})
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 	github.com/nutanix-cloud-native/packer-plugin-nutanix/builder/nutanix/driver.go:933 +0x4d9
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: github.com/nutanix-cloud-native/packer-plugin-nutanix/builder/nutanix.(*StepShutdown).Run(0xc000304180, {0x163ce18, 0xc000782550}, {0x163cc20, 0xc000124930})
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 	github.com/nutanix-cloud-native/packer-plugin-nutanix/builder/nutanix/step_shutdown_vm.go:61 +0x5c2
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: github.com/hashicorp/packer-plugin-sdk/multistep.(*BasicRunner).Run(0xc000124a80, {0x163ce18, 0xc000782550}, {0x163cc20, 0xc000124930})
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 	github.com/hashicorp/packer-plugin-sdk@v0.4.0/multistep/basic_runner.go:73 +0x29b
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: github.com/nutanix-cloud-native/packer-plugin-nutanix/builder/nutanix.(*Builder).Run(0xc0002e1088, {0x163ce18, 0xc000782550}, {0x163fe88, 0xc0001247e0}, {0x162ff40, 0xc000272780})
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 	github.com/nutanix-cloud-native/packer-plugin-nutanix/builder/nutanix/builder.go:85 +0x77d
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: github.com/hashicorp/packer-plugin-sdk/rpc.(*BuilderServer).Run(0xc000139580, 0x1?, 0xc000636040)
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 	github.com/hashicorp/packer-plugin-sdk@v0.4.0/rpc/builder.go:120 +0x1d1
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: reflect.Value.call({0xc0000a42a0?, 0xc000556090?, 0x13?}, {0x11abfe5, 0x4}, {0xc0001b5ef8, 0x3, 0x3?})
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 	reflect/value.go:596 +0xca6
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: reflect.Value.Call({0xc0000a42a0?, 0xc000556090?, 0x0?}, {0xc000188ef8?, 0x0?, 0x0?})
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 	reflect/value.go:380 +0xb9
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: net/rpc.(*service).call(0xc000139700, 0xc000138000, 0xc0007ea000, 0xc0007ea010, 0xc00018e200, 0xc000642040, {0xf90e00?, 0xc00063602c?, 0x0?}, {0xf5d080, ...}, ...)
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 	net/rpc/server.go:381 +0x20e
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: created by net/rpc.(*Server).ServeCodec in goroutine 1
2024/06/05 21:12:30 packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64 plugin: 	net/rpc/server.go:478 +0x3d7
2024/06/05 21:12:30 /home/faiqus/.config/packer/plugins/github.com/nutanix-cloud-native/nutanix/packer-plugin-nutanix_v0.9.0_x5.0_linux_amd64: plugin process exited
2024/06/05 21:12:30 [INFO] (telemetry) ending nutanix.bastion_image
2024/06/05 21:12:30 ui error: Build 'nutanix.bastion_image' errored after 4 minutes 22 seconds: unexpected EOF
2024/06/05 21:12:30 ui: 
==> Wait completed after 4 minutes 22 seconds
2024/06/05 21:12:30 machine readable: error-count []string{"1"}
2024/06/05 21:12:30 ui error: 
==> Some builds didn't complete successfully and had errors:
2024/06/05 21:12:30 machine readable: nutanix.bastion_image,error []string{"unexpected EOF"}
2024/06/05 21:12:30 ui error: --> nutanix.bastion_image: unexpected EOF
2024/06/05 21:12:30 ui: 
==> Builds finished but no artifacts were created.
2024/06/05 21:12:30 [INFO] (telemetry) Finalizing.
2024/06/05 21:12:30 waiting for all plugin processes to complete...
2024/06/05 21:12:30 /home/faiqus/.asdf/installs/packer/1.10.3/bin/packer: plugin process exited
2024/06/05 21:12:30 /home/faiqus/.asdf/installs/packer/1.10.3/bin/packer: plugin process exited
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
