### PR TITLE
remove FIQL filter to avoid bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 0.9.3"
+      version = ">= 0.9.4"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.9.3"
+	Version = "0.9.4"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
**What this PR does / why we need it**:

FIQL filtering has been deprecated by the APIs for some time now. We should avoid using it altogether. We were doing a 2-pass filtering earlier (FIQL + Client Side) and with this change we remove the first pass filtering and all filtering will be done by what was earlier the second pass client side filter.

**How Has This Been Tested?**:

manual test with different subnet name
- VLAN000(NOIPAM)
- VLAN000|NOIPAM
- VLAN000-IPAM

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:

```release-note
- remove server side filtering
```
