### PR TITLE
Feature/checksum

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -86,6 +86,7 @@ Sample:
 - `source_image_delete` (bool) - Delete source image once build process is completed (default is false).
 - `source_image_force` (bool) - Always download and replace source image even if already exist (default is false).
 - `disk_size_gb` (number) - size of the disk (in gigabytes).
+- `checksum` (block) - Checksum block containing checksum algorithm and checksum value
 
 Sample:
 ```hcl
@@ -93,6 +94,10 @@ Sample:
       image_type = "DISK_IMAGE"
       source_image_name = "<myDiskImage>"
       disk_size_gb = 40
+      checksum {
+        checksum_algorithm = "SHA_256"
+        checksum_value = "<checksumValue>"
+      }
   }
 ```
 ### ISO Image

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -1,4 +1,4 @@
-//go:generate packer-sdc mapstructure-to-hcl2 -type Config,Category,ClusterConfig,VmConfig,VmDisk,VmNIC,GPU
+//go:generate packer-sdc mapstructure-to-hcl2 -type Config,Category,ClusterConfig,VmConfig,VmDisk,VmNIC,GPU,Checksum
 
 package nutanix
 
@@ -61,14 +61,20 @@ type ClusterConfig struct {
 	Port     int32  `mapstructure:"nutanix_port" required:"false"`
 }
 
+type Checksum struct {
+	ChecksumAlgorithm string `json:"checksum_algorithm" mapstructure:"checksum_algorithm" required:"false"`
+	ChecksumValue     string `json:"checksum_value" mapstructure:"checksum_value" required:"false"`
+}
+
 type VmDisk struct {
-	ImageType         string `mapstructure:"image_type" json:"image_type" required:"false"`
-	SourceImageName   string `mapstructure:"source_image_name" json:"source_image_name" required:"false"`
-	SourceImageUUID   string `mapstructure:"source_image_uuid" json:"source_image_uuid" required:"false"`
-	SourceImageURI    string `mapstructure:"source_image_uri" json:"source_image_uri" required:"false"`
-	SourceImageDelete bool   `mapstructure:"source_image_delete" json:"source_image_delete" required:"false"`
-	SourceImageForce  bool   `mapstructure:"source_image_force" json:"source_image_force" required:"false"`
-	DiskSizeGB        int64  `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false"`
+	ImageType         string   `mapstructure:"image_type" json:"image_type" required:"false"`
+	SourceImageName   string   `mapstructure:"source_image_name" json:"source_image_name" required:"false"`
+	SourceImageUUID   string   `mapstructure:"source_image_uuid" json:"source_image_uuid" required:"false"`
+	SourceImageURI    string   `mapstructure:"source_image_uri" json:"source_image_uri" required:"false"`
+	SourceImageDelete bool     `mapstructure:"source_image_delete" json:"source_image_delete" required:"false"`
+	SourceImageForce  bool     `mapstructure:"source_image_force" json:"source_image_force" required:"false"`
+	DiskSizeGB        int64    `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false"`
+	Checksum          Checksum `mapstructure:"checksum,omitempty" json:"checksum,omitempty"  required:"false"`
 }
 
 type VmNIC struct {

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -32,6 +32,31 @@ func (*FlatCategory) HCL2Spec() map[string]hcldec.Spec {
 	return s
 }
 
+// FlatChecksum is an auto-generated flat version of Checksum.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatChecksum struct {
+	ChecksumAlgorithm *string `json:"checksum_algorithm" mapstructure:"checksum_algorithm" required:"false" cty:"checksum_algorithm" hcl:"checksum_algorithm"`
+	ChecksumValue     *string `json:"checksum_value" mapstructure:"checksum_value" required:"false" cty:"checksum_value" hcl:"checksum_value"`
+}
+
+// FlatMapstructure returns a new FlatChecksum.
+// FlatChecksum is an auto-generated flat version of Checksum.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*Checksum) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatChecksum)
+}
+
+// HCL2Spec returns the hcl spec of a Checksum.
+// This spec is used by HCL to read the fields of Checksum.
+// The decoded values from this spec will then be applied to a FlatChecksum.
+func (*FlatChecksum) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"checksum_algorithm": &hcldec.AttrSpec{Name: "checksum_algorithm", Type: cty.String, Required: false},
+		"checksum_value":     &hcldec.AttrSpec{Name: "checksum_value", Type: cty.String, Required: false},
+	}
+	return s
+}
+
 // FlatClusterConfig is an auto-generated flat version of ClusterConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatClusterConfig struct {
@@ -335,13 +360,14 @@ func (*FlatVmConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatVmDisk is an auto-generated flat version of VmDisk.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatVmDisk struct {
-	ImageType         *string `mapstructure:"image_type" json:"image_type" required:"false" cty:"image_type" hcl:"image_type"`
-	SourceImageName   *string `mapstructure:"source_image_name" json:"source_image_name" required:"false" cty:"source_image_name" hcl:"source_image_name"`
-	SourceImageUUID   *string `mapstructure:"source_image_uuid" json:"source_image_uuid" required:"false" cty:"source_image_uuid" hcl:"source_image_uuid"`
-	SourceImageURI    *string `mapstructure:"source_image_uri" json:"source_image_uri" required:"false" cty:"source_image_uri" hcl:"source_image_uri"`
-	SourceImageDelete *bool   `mapstructure:"source_image_delete" json:"source_image_delete" required:"false" cty:"source_image_delete" hcl:"source_image_delete"`
-	SourceImageForce  *bool   `mapstructure:"source_image_force" json:"source_image_force" required:"false" cty:"source_image_force" hcl:"source_image_force"`
-	DiskSizeGB        *int64  `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false" cty:"disk_size_gb" hcl:"disk_size_gb"`
+	ImageType         *string       `mapstructure:"image_type" json:"image_type" required:"false" cty:"image_type" hcl:"image_type"`
+	SourceImageName   *string       `mapstructure:"source_image_name" json:"source_image_name" required:"false" cty:"source_image_name" hcl:"source_image_name"`
+	SourceImageUUID   *string       `mapstructure:"source_image_uuid" json:"source_image_uuid" required:"false" cty:"source_image_uuid" hcl:"source_image_uuid"`
+	SourceImageURI    *string       `mapstructure:"source_image_uri" json:"source_image_uri" required:"false" cty:"source_image_uri" hcl:"source_image_uri"`
+	SourceImageDelete *bool         `mapstructure:"source_image_delete" json:"source_image_delete" required:"false" cty:"source_image_delete" hcl:"source_image_delete"`
+	SourceImageForce  *bool         `mapstructure:"source_image_force" json:"source_image_force" required:"false" cty:"source_image_force" hcl:"source_image_force"`
+	DiskSizeGB        *int64        `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false" cty:"disk_size_gb" hcl:"disk_size_gb"`
+	Checksum          *FlatChecksum `mapstructure:"checksum,omitempty" json:"checksum,omitempty" required:"false" cty:"checksum" hcl:"checksum"`
 }
 
 // FlatMapstructure returns a new FlatVmDisk.
@@ -363,6 +389,7 @@ func (*FlatVmDisk) HCL2Spec() map[string]hcldec.Spec {
 		"source_image_delete": &hcldec.AttrSpec{Name: "source_image_delete", Type: cty.Bool, Required: false},
 		"source_image_force":  &hcldec.AttrSpec{Name: "source_image_force", Type: cty.Bool, Required: false},
 		"disk_size_gb":        &hcldec.AttrSpec{Name: "disk_size_gb", Type: cty.Number, Required: false},
+		"checksum":            &hcldec.BlockSpec{TypeName: "checksum", Nested: hcldec.ObjectSpec((*FlatChecksum)(nil).HCL2Spec())},
 	}
 	return s
 }

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -682,6 +682,10 @@ func (d *NutanixDriver) CreateImageURL(ctx context.Context, disk VmDisk, vm VmCo
 		Spec: &v3.Image{
 			Name: &file,
 			Resources: &v3.ImageResources{
+				Checksum: &v3.Checksum{
+					ChecksumAlgorithm: &disk.Checksum.ChecksumAlgorithm,
+					ChecksumValue:     &disk.Checksum.ChecksumValue,
+				},
 				ImageType:               &disk.ImageType,
 				InitialPlacementRefList: InitialPlacementRef,
 			},

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -95,6 +95,7 @@ Sample:
 - `source_image_delete` (bool) - Delete source image once build process is completed (default is false).
 - `source_image_force` (bool) - Always download and replace source image even if already exist (default is false).
 - `disk_size_gb` (number) - size of the disk (in gigabytes).
+- `checksum` (block) - Checksum block containing checksum algorithm and checksum value
 
 Sample:
 ```hcl
@@ -102,6 +103,10 @@ Sample:
       image_type = "DISK_IMAGE"
       source_image_name = "<myDiskImage>"
       disk_size_gb = 40
+      checksum {
+        checksum_algorithm = "SHA_256"
+        checksum_value = "<checksumValue>"
+      }
   }
 ```
 ### ISO Image

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/hashicorp/hcl/v2 v2.23.0
-	github.com/hashicorp/packer-plugin-sdk v0.5.4
+	github.com/hashicorp/packer-plugin-sdk v0.5.2
 	github.com/nutanix-cloud-native/prism-go-client v0.5.1
 	github.com/zclconf/go-cty v1.15.1
 )
@@ -103,7 +103,7 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
-	golang.org/x/mod v0.22.0 // indirect
+	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
@@ -111,7 +111,7 @@ require (
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	golang.org/x/tools v0.28.0 // indirect
+	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.150.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
 github.com/hashicorp/memberlist v0.5.0 h1:EtYPN8DpAURiapus508I4n9CzHs2W+8NZGbmmR/prTM=
 github.com/hashicorp/memberlist v0.5.0/go.mod h1:yvyXLpo0QaGE59Y7hDTsTzDD25JYBZ4mHgHUZ8lrOI0=
-github.com/hashicorp/packer-plugin-sdk v0.5.4 h1:5Bl5DMEa//G4gBNcl842JopM9L4KSSsxpvB4W1lEwIA=
-github.com/hashicorp/packer-plugin-sdk v0.5.4/go.mod h1:ALm0ZIK3c/F4iOqPNi7xVuHTgrR5dxzOK+DhFN5DHj4=
+github.com/hashicorp/packer-plugin-sdk v0.5.2 h1:N+9qzkZLkjR0bgY+l5wFvrTN0G/Mf9f7g2yLsrDjmFI=
+github.com/hashicorp/packer-plugin-sdk v0.5.2/go.mod h1:0LRUBS6CPClHvq6zPoGRi7C+cZDAIEaW4CeH4LhWWuc=
 github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
 github.com/hashicorp/vault/api v1.14.0 h1:Ah3CFLixD5jmjusOgm8grfN9M0d+Y8fVR2SW0K6pJLU=
@@ -422,8 +422,8 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
-golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -500,8 +500,8 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.28.0 h1:WuB6qZ4RPCQo5aP3WdKZS7i595EdWqWR8vqJTlwTVK8=
-golang.org/x/tools v0.28.0/go.mod h1:dcIOrVd3mfQKTgrDVQHqCPMWy6lnhfhtX3hLXYVLfRw=
+golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
+golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=

--- a/test/e2e/centos-img/source.pkr.hcl
+++ b/test/e2e/centos-img/source.pkr.hcl
@@ -11,6 +11,10 @@ source "nutanix" "centos" {
       image_type = "DISK_IMAGE"
       source_image_uri = "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2111.qcow2"
       disk_size_gb = 20
+      checksum {
+        checksum_algorithm = "SHA_256"
+        checksum_value = "4c34278cd7ba51e47d864a5cb34301a2ec7853786cb73877f3fe61bb1040edd4"
+      }
   }
 
   vm_nics {

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.9.4"
+	Version = "0.10.0"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
@@ -18,5 +18,5 @@ var (
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.
-	PluginVersion = version.NewPluginVersion(Version, VersionPrerelease, VersionMetadata)
+	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/packer-plugin-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #208

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_

Tested with the following variables:

```
ubuntu_disk_image_uri = "https://releases.ubuntu.com/24.04.1/ubuntu-24.04.1-live-server-amd64.iso"
checksum_algo = "SHA_256"
checksum_value = "e240e4b801f7bb68c20d1356b60968ad0c33a41d00d828e74ceb3364a0317be9"
```

Wrong checksum length:

```
==> nutanix.ubuntu: Error creating virtual machine request: error while findImageByUUID, Error error while creating image: INVALID_ARGUMENT: Given input is invalid. Invalid length of checksum.
Build 'nutanix.ubuntu' errored after 42 seconds 212 milliseconds: error while findImageByUUID, Error error while creating image: INVALID_ARGUMENT: Given input is invalid. Invalid length of checksum.
```

Wrong algorithm:

```
==> nutanix.ubuntu: Creating Packer Builder virtual machine...
==> nutanix.ubuntu: Error creating virtual machine request: error while findImageByUUID, Error error while creating image: status: 422 Unprocessable Entity, error-response: {
==> nutanix.ubuntu:   "api_version": "3.1",
==> nutanix.ubuntu:   "code": 422,
==> nutanix.ubuntu:   "message_list": [
==> nutanix.ubuntu:     {
==> nutanix.ubuntu:       "details": {
==> nutanix.ubuntu:         "spec.resources.checksum.checksum_algorithm": [
==> nutanix.ubuntu:           "'sha256' is not one of ['SHA_256', 'SHA_1']"
==> nutanix.ubuntu:         ]
==> nutanix.ubuntu:       },
==> nutanix.ubuntu:       "message": "Request could not be processed.",
==> nutanix.ubuntu:       "reason": "INVALID_REQUEST"
==> nutanix.ubuntu:     }
==> nutanix.ubuntu:   ],
==> nutanix.ubuntu:   "state": "ERROR"
==> nutanix.ubuntu: }
Build 'nutanix.ubuntu' errored after 34 seconds 37 milliseconds: error while findImageByUUID, Error error while creating image: status: 422 Unprocessable Entity, error-response: {
  "api_version": "3.1",
  "code": 422,
  "message_list": [
    {
      "details": {
        "spec.resources.checksum.checksum_algorithm": [
          "'sha256' is not one of ['SHA_256', 'SHA_1']"
        ]
      },
      "message": "Request could not be processed.",
      "reason": "INVALID_REQUEST"
    }
  ],
  "state": "ERROR"
}

==> Wait completed after 34 seconds 37 milliseconds

==> Some builds didn't complete successfully and had errors:
--> nutanix.ubuntu: error while findImageByUUID, Error error while creating image: status: 422 Unprocessable Entity, error-response: {
  "api_version": "3.1",
  "code": 422,
  "message_list": [
    {
      "details": {
        "spec.resources.checksum.checksum_algorithm": [
          "'sha256' is not one of ['SHA_256', 'SHA_1']"
        ]
      },
      "message": "Request could not be processed.",
      "reason": "INVALID_REQUEST"
    }
  ],
  "state": "ERROR"
}

==> Builds finished but no artifacts were created.
```

Wrong checksum

```
==> nutanix.ubuntu: Creating Packer Builder virtual machine...
==> nutanix.ubuntu: Error creating virtual machine request: error while findImageByUUID, Error error while creating image: INTERNAL_ERROR: ImageCreate failed. nubera - Incorrect checksum provided in request b'e240e4b801f7bb68c20d1356b60968ad0c33a41d00d828e74ceb3364a0317be8'.
Build 'nutanix.ubuntu' errored after 3 minutes 14 seconds: error while findImageByUUID, Error error while creating image: INTERNAL_ERROR: ImageCreate failed. nubera - Incorrect checksum provided in request b'e240e4b801f7bb68c20d1356b60968ad0c33a41d00d828e74ceb3364a0317be8'.
```

**Special notes for your reviewer**:

@tuxtof 
I had to make some changes to the go.mod, due to go generate of config.go not working properly, which I fixed by following the comments in this issue: https://github.com/hashicorp/packer-plugin-sdk/issues/131

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add optional variables for checksum verification
```
