### PR TITLE
prepare for v0.11.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 0.10.0"
+      version = ">= 0.11.0"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.10.0"
+	Version = "0.11.0"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
**What this PR does / why we need it**:

prepare for v0.11.0 release
