### PR TITLE
Add Serial Port Support to packer-plugin-nutanix

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -27,6 +27,7 @@ These parameters allow to define information about platform and temporary VM use
   - `vm_categories` ([]Category) - Assign Categories to the vm.
   - `project` (string) - Assign Project to the vm.
   - `gpu` ([] GPU) - GPU in cluster name to be attached on temporary VM.
+  - `serialport` (bool) - Add a serial port to the temporary VM. This is required for some Linux Cloud Images that will have a kernel panic if a serial port is not present on first boot.
 
 
 ## Output configuration

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -105,6 +105,7 @@ type VmConfig struct {
 	VMCategories []Category `mapstructure:"vm_categories" required:"false"`
 	Project      string     `mapstructure:"project" required:"false"`
 	GPU          []GPU      `mapstructure:"gpu" required:"false"`
+	SerialPorts  int64      `mapstructure:"serialports" json:"serialports" required:"false"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -105,7 +105,7 @@ type VmConfig struct {
 	VMCategories []Category `mapstructure:"vm_categories" required:"false"`
 	Project      string     `mapstructure:"project" required:"false"`
 	GPU          []GPU      `mapstructure:"gpu" required:"false"`
-	SerialPorts  int64      `mapstructure:"serialports" json:"serialports" required:"false"`
+	SerialPort   bool       `mapstructure:"serialport" json:"serialport" required:"false"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -148,7 +148,7 @@ type FlatConfig struct {
 	VMCategories              []FlatCategory    `mapstructure:"vm_categories" required:"false" cty:"vm_categories" hcl:"vm_categories"`
 	Project                   *string           `mapstructure:"project" required:"false" cty:"project" hcl:"project"`
 	GPU                       []FlatGPU         `mapstructure:"gpu" required:"false" cty:"gpu" hcl:"gpu"`
-	SerialPorts               *int64            `mapstructure:"serialports" json:"serialports" required:"false" cty:"serialports" hcl:"serialports"`
+	SerialPort                *bool             `mapstructure:"serialport" json:"serialport" required:"false" cty:"serialport" hcl:"serialport"`
 	ForceDeregister           *bool             `mapstructure:"force_deregister" json:"force_deregister" required:"false" cty:"force_deregister" hcl:"force_deregister"`
 	ImageDescription          *string           `mapstructure:"image_description" json:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageCategories           []FlatCategory    `mapstructure:"image_categories" required:"false" cty:"image_categories" hcl:"image_categories"`
@@ -252,7 +252,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_categories":                &hcldec.BlockListSpec{TypeName: "vm_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
 		"project":                      &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"gpu":                          &hcldec.BlockListSpec{TypeName: "gpu", Nested: hcldec.ObjectSpec((*FlatGPU)(nil).HCL2Spec())},
-		"serialports":                  &hcldec.AttrSpec{Name: "serialports", Type: cty.Number, Required: false},
+		"serialport":                   &hcldec.AttrSpec{Name: "serialport", Type: cty.Bool, Required: false},
 		"force_deregister":             &hcldec.AttrSpec{Name: "force_deregister", Type: cty.Bool, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_categories":             &hcldec.BlockListSpec{TypeName: "image_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
@@ -305,7 +305,7 @@ type FlatVmConfig struct {
 	VMCategories []FlatCategory `mapstructure:"vm_categories" required:"false" cty:"vm_categories" hcl:"vm_categories"`
 	Project      *string        `mapstructure:"project" required:"false" cty:"project" hcl:"project"`
 	GPU          []FlatGPU      `mapstructure:"gpu" required:"false" cty:"gpu" hcl:"gpu"`
-	SerialPorts  *int64         `mapstructure:"serialports" json:"serialports" required:"false" cty:"serialports" hcl:"serialports"`
+	SerialPort   *bool          `mapstructure:"serialport" json:"serialport" required:"false" cty:"serialport" hcl:"serialport"`
 }
 
 // FlatMapstructure returns a new FlatVmConfig.
@@ -335,7 +335,7 @@ func (*FlatVmConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_categories": &hcldec.BlockListSpec{TypeName: "vm_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
 		"project":       &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"gpu":           &hcldec.BlockListSpec{TypeName: "gpu", Nested: hcldec.ObjectSpec((*FlatGPU)(nil).HCL2Spec())},
-		"serialports":   &hcldec.AttrSpec{Name: "serialports", Type: cty.Number, Required: false},
+		"serialport":    &hcldec.AttrSpec{Name: "serialport", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -148,6 +148,7 @@ type FlatConfig struct {
 	VMCategories              []FlatCategory    `mapstructure:"vm_categories" required:"false" cty:"vm_categories" hcl:"vm_categories"`
 	Project                   *string           `mapstructure:"project" required:"false" cty:"project" hcl:"project"`
 	GPU                       []FlatGPU         `mapstructure:"gpu" required:"false" cty:"gpu" hcl:"gpu"`
+	SerialPorts               *int64            `mapstructure:"serialports" json:"serialports" required:"false" cty:"serialports" hcl:"serialports"`
 	ForceDeregister           *bool             `mapstructure:"force_deregister" json:"force_deregister" required:"false" cty:"force_deregister" hcl:"force_deregister"`
 	ImageDescription          *string           `mapstructure:"image_description" json:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageCategories           []FlatCategory    `mapstructure:"image_categories" required:"false" cty:"image_categories" hcl:"image_categories"`
@@ -251,6 +252,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_categories":                &hcldec.BlockListSpec{TypeName: "vm_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
 		"project":                      &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"gpu":                          &hcldec.BlockListSpec{TypeName: "gpu", Nested: hcldec.ObjectSpec((*FlatGPU)(nil).HCL2Spec())},
+		"serialports":                  &hcldec.AttrSpec{Name: "serialports", Type: cty.Number, Required: false},
 		"force_deregister":             &hcldec.AttrSpec{Name: "force_deregister", Type: cty.Bool, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_categories":             &hcldec.BlockListSpec{TypeName: "image_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
@@ -303,6 +305,7 @@ type FlatVmConfig struct {
 	VMCategories []FlatCategory `mapstructure:"vm_categories" required:"false" cty:"vm_categories" hcl:"vm_categories"`
 	Project      *string        `mapstructure:"project" required:"false" cty:"project" hcl:"project"`
 	GPU          []FlatGPU      `mapstructure:"gpu" required:"false" cty:"gpu" hcl:"gpu"`
+	SerialPorts  *int64         `mapstructure:"serialports" json:"serialports" required:"false" cty:"serialports" hcl:"serialports"`
 }
 
 // FlatMapstructure returns a new FlatVmConfig.
@@ -332,6 +335,7 @@ func (*FlatVmConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_categories": &hcldec.BlockListSpec{TypeName: "vm_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
 		"project":       &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"gpu":           &hcldec.BlockListSpec{TypeName: "gpu", Nested: hcldec.ObjectSpec((*FlatGPU)(nil).HCL2Spec())},
+		"serialports":   &hcldec.AttrSpec{Name: "serialports", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -505,6 +505,19 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vm VmConfig, state mu
 		NICList = append(NICList, &newNIC)
 	}
 
+	SerialIndex := 0
+	SerialPortList := []*v3.VMSerialPort{}
+	for ok := true; ok; ok = (SerialIndex < int(vm.SerialPorts)) {
+		DeviceIndex := int64(SerialIndex)
+		isConnected := true
+		newVMSerialPort := v3.VMSerialPort{
+			Index:       &DeviceIndex,
+			IsConnected: &isConnected,
+		}
+		SerialPortList = append(SerialPortList, &newVMSerialPort)
+		SerialIndex++
+	}
+
 	GPUList := make([]*v3.VMGpu, 0, len(vm.GPU))
 	for _, gpu := range vm.GPU {
 		vmGPU, err := findGPUByName(ctx, conn, gpu.Name)
@@ -526,6 +539,7 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vm VmConfig, state mu
 				DiskList:           DiskList,
 				NicList:            NICList,
 				GpuList:            GPUList,
+				SerialPortList:     SerialPortList,
 			},
 			ClusterReference: BuildReference(*cluster.Metadata.UUID, "cluster"),
 			Description:      StringPtr(fmt.Sprintf(vmDescription, d.Config.VmConfig.ImageName)),

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -515,7 +515,6 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vm VmConfig, state mu
 			IsConnected: &isConnected,
 		}
 		SerialPortList = append(SerialPortList, &newVMSerialPort)
-		SerialIndex++
 	}
 
 	GPUList := make([]*v3.VMGpu, 0, len(vm.GPU))

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -507,7 +507,7 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vm VmConfig, state mu
 
 	SerialIndex := 0
 	SerialPortList := []*v3.VMSerialPort{}
-	for ok := true; ok; ok = (SerialIndex < int(vm.SerialPorts)) {
+	if vm.SerialPort {
 		DeviceIndex := int64(SerialIndex)
 		isConnected := true
 		newVMSerialPort := v3.VMSerialPort{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/packer-plugin-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds support for adding a serial port to a Nutanix VM when using Packer.  A serial port is required for some preconfigured Linux distribution cloud images (like Debian and Ubuntu) to prevent a kernel panic on first boot that will cause the Packer build to time out and fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #225

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_

Imported the following Debian pre-configured Generic Cloud Image into Prism Central: https://cloud.debian.org/images/cloud/bookworm/20250115-1993/debian-12-genericcloud-amd64-20250115-1993.raw

Used the Packer Build files attached below to generate new VMs.  Local user is templatebuilder, testing password is Unbent1-Anguished-Whimsical
[Compressed for Github.zip](https://github.com/user-attachments/files/18716931/Compressed.for.Github.zip)

Ran one build with serialport = true and saw it complete the build succesfully and add the disk image to the image library.
Ran one build with serialport = false. When I logged into Prism Central and viewed the new VM console, it had a kernel panic.

**Special notes for your reviewer**:

This is my first PR for this project.  It solves a problem that I ran into in my home lab.

I also updated the builder documentation to include this change.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

none that I am aware of.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Adds support for adding a single serial port.
```
