### PR TITLE
add secure boot (#181)

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -21,7 +21,7 @@ These parameters allow to define information about platform and temporary VM use
   - `memory_mb` (number) - Size of vRAM for temporary VM (in megabytes).
   - `cd_files` (array of strings) - A list of files to place onto a CD that is attached when the VM is booted. This can include either files or directories; any directories will be copied onto the CD recursively, preserving directory structure hierarchy.
   - `cd_label` (string) - Label of this CD Drive.
-  - `boot_type` (string) - Type of boot used on the temporary VM ("legacy" or "uefi", default is "legacy").
+  - `boot_type` (string) - Type of boot used on the temporary VM ("legacy", "uefi" or "secure_boot", default is "legacy").
   - `boot_priority` (string) - Priority of boot device ("cdrom" or "disk", default is "cdrom").
   - `ip_wait_timeout` (duration string | ex: "0h42m0s") - Amount of time to wait for VM's IP, similar to 'ssh_timeout'. Defaults to 15m (15 minutes). See the Golang [ParseDuration](https://golang.org/pkg/time/#ParseDuration) documentation for full details.
   - `vm_categories` ([]Category) - Assign Categories to the vm.

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -25,6 +25,9 @@ const (
 	// NutanixIdentifierBootTypeUEFI is a resource identifier identifying the UEFI boot type for virtual machines.
 	NutanixIdentifierBootTypeUEFI string = "uefi"
 
+	// NutanixIdentifierBootTypeSecure is a resource identifier identifying the secure boot type for virtual machines.
+	NutanixIdentifierBootTypeSecure string = "secure_boot"
+
 	// NutanixIdentifierBootPriorityDisk is a resource identifier identifying the boot priority as disk for virtual machines.
 	NutanixIdentifierBootPriorityDisk string = "disk"
 
@@ -92,6 +95,7 @@ type VmNIC struct {
 type VmConfig struct {
 	VMName       string     `mapstructure:"vm_name" json:"vm_name" required:"false"`
 	OSType       string     `mapstructure:"os_type" json:"os_type" required:"true"`
+	MachineType  string     `mapstructure:"machine_type" json:"machine_type" required:"false"`
 	BootType     string     `mapstructure:"boot_type" json:"boot_type" required:"false"`
 	BootPriority string     `mapstructure:"boot_priority" json:"boot_priority" required:"false"`
 	VmDisks      []VmDisk   `mapstructure:"vm_disks"`
@@ -146,7 +150,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		c.ClusterConfig.Port = 9440
 	}
 
-	if c.BootType != NutanixIdentifierBootTypeLegacy && c.BootType != NutanixIdentifierBootTypeUEFI {
+	if c.BootType != NutanixIdentifierBootTypeLegacy && c.BootType != NutanixIdentifierBootTypeUEFI && c.BootType != NutanixIdentifierBootTypeSecure {
 		log.Println("No correct VM Boot Type configured, defaulting to 'legacy'")
 		c.BootType = string(NutanixIdentifierBootTypeLegacy)
 	}
@@ -154,6 +158,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	if c.BootType == NutanixIdentifierBootTypeUEFI && c.BootPriority != "" {
 		log.Println("Boot Priority is not supported for UEFI boot type")
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("UEFI does not support boot priority"))
+	}
+
+	if c.BootType == NutanixIdentifierBootTypeSecure && c.BootPriority != "" {
+		log.Println("Boot Priority is not supported for secure boot type")
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Secure boot does not support boot priority"))
 	}
 
 	if c.BootPriority != NutanixIdentifierBootPriorityDisk && c.BootPriority != NutanixIdentifierBootPriorityCDROM {

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -95,7 +95,6 @@ type VmNIC struct {
 type VmConfig struct {
 	VMName       string     `mapstructure:"vm_name" json:"vm_name" required:"false"`
 	OSType       string     `mapstructure:"os_type" json:"os_type" required:"true"`
-	MachineType  string     `mapstructure:"machine_type" json:"machine_type" required:"false"`
 	BootType     string     `mapstructure:"boot_type" json:"boot_type" required:"false"`
 	BootPriority string     `mapstructure:"boot_priority" json:"boot_priority" required:"false"`
 	VmDisks      []VmDisk   `mapstructure:"vm_disks"`

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -161,7 +161,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.BootType == NutanixIdentifierBootTypeSecure && c.BootPriority != "" {
 		log.Println("Boot Priority is not supported for secure boot type")
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Secure boot does not support boot priority"))
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("secure boot does not support boot priority"))
 	}
 
 	if c.BootPriority != NutanixIdentifierBootPriorityDisk && c.BootPriority != NutanixIdentifierBootPriorityCDROM {

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -554,6 +554,14 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vm VmConfig, state mu
 		req.Spec.Resources.BootConfig = &v3.VMBootConfig{
 			BootType: &bootType,
 		}
+	} else if vm.BootType == NutanixIdentifierBootTypeSecure {
+		bootType := strings.ToUpper(NutanixIdentifierBootTypeSecure)
+
+		req.Spec.Resources.BootConfig = &v3.VMBootConfig{
+		BootType: &bootType,
+		}
+		// Force machine type to "Q35", which is required for Secure Boot
+		req.Spec.Resources.MachineType = StringPtr("Q35")
 	} else {
 		bootType := strings.ToUpper(NutanixIdentifierBootTypeLegacy)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Thi PR implement "Secure Boot" option

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #181 (but some comments asked also for vtpm which is not covered by this PR)

**How Has This Been Tested?**:
Deploy one VM with `boot_type = secure_boot`.
Deploy a second VM with `boot_type` unset.

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add secure boot option
```
