### PR TITLE
Fix IP wait workflow

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 0.13.0"
+      version = ">= 0.13.1"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -23,7 +23,6 @@ These parameters allow to define information about platform and temporary VM use
   - `cd_label` (string) - Label of this CD Drive.
   - `boot_type` (string) - Type of boot used on the temporary VM ("legacy" or "uefi", default is "legacy").
   - `boot_priority` (string) - Priority of boot device ("cdrom" or "disk", default is "cdrom". UEFI support need AHV 8.0.12+, 9.1.1.2+, 9.1.3+, 9.2+ or 10.0+). 
-  - `ip_wait_timeout` (duration string | ex: "0h42m0s") - Amount of time to wait for VM's IP, similar to 'ssh_timeout'. Defaults to 15m (15 minutes). See the Golang [ParseDuration](https://golang.org/pkg/time/#ParseDuration) documentation for full details.
   - `vm_categories` ([]Category) - Assign Categories to the vm.
   - `project` (string) - Assign Project to the vm.
   - `gpu` ([] GPU) - GPU in cluster name to be attached on temporary VM.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 0.13.0"
+      version = ">= 0.13.1"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/builder/nutanix/builder.go
+++ b/builder/nutanix/builder.go
@@ -63,8 +63,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&stepBuildVM{},
 		&stepVNCConnect{
-			VNCEnabled:    !b.config.DisableVNC,
-			ClusterConfig: &b.config.ClusterConfig,
+			Config: &b.config,
 		},
 		&stepVNCBootCommand{
 			Config: &b.config,

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -282,11 +282,6 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		c.CommConfig.SSHTimeout = 20 * time.Minute
 	}
 
-	// Define default ip_wait_timeout to 15 min
-	if c.WaitTimeout == 0 {
-		c.WaitTimeout = 15 * time.Minute
-	}
-
 	errs = packersdk.MultiErrorAppend(errs, c.ShutdownConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.CDConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.CommConfig.Prepare(&c.ctx)...)

--- a/builder/nutanix/step_vnc_boot_command.go
+++ b/builder/nutanix/step_vnc_boot_command.go
@@ -18,6 +18,10 @@ type stepVNCBootCommand struct {
 }
 
 func (s *stepVNCBootCommand) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	if s.Config.BootCommand == nil {
+		return multistep.ActionContinue
+	}
+
 	if s.Config.DisableVNC {
 		log.Println("Skipping boot command step...")
 		return multistep.ActionContinue

--- a/builder/nutanix/step_wait_for_ip.go
+++ b/builder/nutanix/step_wait_for_ip.go
@@ -85,8 +85,9 @@ func (s *stepWaitForIp) Run(ctx context.Context, state multistep.StateBag) multi
 		cancel()
 	}()
 
+	ui.Say("Waiting for IP...")
+
 	go func() {
-		ui.Say("Waiting for IP...")
 		ip, err = doGetIp(d, vm, sub, s.Config)
 		waitDone <- true
 	}()

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 0.13.0"
+      version = ">= 0.13.1"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -32,7 +32,6 @@ These parameters allow to define information about platform and temporary VM use
   - `cd_label` (string) - Label of this CD Drive.
   - `boot_type` (string) - Type of boot used on the temporary VM ("legacy" or "uefi", default is "legacy").
   - `boot_priority` (string) - Priority of boot device ("cdrom" or "disk", default is "cdrom". UEFI support need AHV 8.0.12+, 9.1.1.2+, 9.1.3+, 9.2+ or 10.0+). 
-  - `ip_wait_timeout` (duration string | ex: "0h42m0s") - Amount of time to wait for VM's IP, similar to 'ssh_timeout'. Defaults to 15m (15 minutes). See the Golang [ParseDuration](https://golang.org/pkg/time/#ParseDuration) documentation for full details.
   - `vm_categories` ([]Category) - Assign Categories to the vm.
   - `project` (string) - Assign Project to the vm.
   - `gpu` ([] GPU) - GPU in cluster name to be attached on temporary VM.

--- a/example/init/plugin.pkr.hcl
+++ b/example/init/plugin.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 0.13.0"
+      version = ">= 0.13.1"
       source = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.13.0"
+	Version = "0.13.1"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
This pull request includes several updates to the Nutanix Packer plugin, focusing on version upgrades, configuration simplifications, and improvements to the handling of VM IP retrieval and VNC connections. Below is a summary of the most important changes grouped by theme:

### Fix:
* Allow `wait_for_ip` step to work correctly with non IPAM subnet
* Skip `boot_command` steps if nothing configured

### Version Updates:
* Updated the Nutanix plugin version from `0.13.0` to `0.13.1` across multiple files, including `.web-docs/README.md`, `README.md`, `docs/README.md`, `example/init/plugin.pkr.hcl`, and `version/version.go`. This ensures compatibility with the latest features and fixes. [[1]](diffhunk://#diff-d240320fc87f7ae14f8d7a62c2cd1db6f4676aa33fa78d3c48a1d3d9c4c550c8L12-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35) [[3]](diffhunk://#diff-d240320fc87f7ae14f8d7a62c2cd1db6f4676aa33fa78d3c48a1d3d9c4c550c8L12-R12) [[4]](diffhunk://#diff-4b426eaaccdd978290702f4b4bdc2d14e7159fdff8592ab1f47c9f9fe949db68L4-R4) [[5]](diffhunk://#diff-f6bf0ae0d21c9408c6624174da11dafb369ce306f2cdcea704285d8acc87e19eL9-R9)

### Configuration Simplifications:
* Consolidated VNC-related configurations into a single `Config` struct, replacing individual fields such as `VNCEnabled`, `ClusterConfig`, and `InsecureConnection` in `builder/nutanix/step_vnc_connect.go`. [[1]](diffhunk://#diff-3099b23d100f564975a9c13e895888216bf0befd5493b8792454be30f1f7fab5L66-R66) [[2]](diffhunk://#diff-59aee3d093884086a67ebc5d6fdbe9cb38039ceff1518b2d4dce421e01dd6023L22-L31)

### Improvements to VM IP Retrieval:
* Enhanced the `WaitForIP` method in `builder/nutanix/driver.go` to include a retry mechanism, ensuring the VM's IP is reliably retrieved even if it is not immediately available (with non IPAM subnet for example).

### VNC Connection Enhancements:
* Improved handling of VNC connections by adding checks for `BootCommand` and `DisableVNC` configurations in `builder/nutanix/step_vnc_boot_command.go` and `builder/nutanix/step_vnc_connect.go`, preventing unnecessary operations when VNC is disabled or boot commands are not defined. [[1]](diffhunk://#diff-3481e0fbf567991a6f9df10b4182a6ec99d91f0c9917a24a4f6d7df91d950942R21-R24) [[2]](diffhunk://#diff-59aee3d093884086a67ebc5d6fdbe9cb38039ceff1518b2d4dce421e01dd6023L22-L31)

### Documentation Updates:
* Removed duplicate references to `ip_wait_timeout` from `.web-docs/components/builder/nutanix/README.md` and `docs/builders/nutanix.mdx`, aligning the documentation with the simplified configuration. [[1]](diffhunk://#diff-785699748597f8f41fe692d5800dcfc25e10ad1de6880a8da23ee7c995ab0e34L26) [[2]](diffhunk://#diff-e3bf31fea91fb90e9499f61d7e60f31d685ff58b8e730ef12fdc6f62c275bbdaL35)