### PR TITLE
quick ova fix

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -37,7 +37,7 @@ These parameters allow to configure everything around image creation, from the t
 - `image_categories` ([]Category) - Assign Categories to the image.
 - `force_deregister` (bool) - Allow output image override if already exists.
 - `image_delete` (bool) - Delete image once build process is completed (default is false).
-- `image_export` (bool) - Export image in the current folder (default is false).
+- `image_export` (bool) - Export raw image in the current folder (default is false).
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -238,11 +238,12 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	// Set name for OVA if not provided
 	if c.OvaConfig.Create && c.OvaConfig.Name == "" {
+		log.Println("No ova.name defined, setting to vm_name")
 		c.OvaConfig.Name = c.VmConfig.VMName
 	}
 
 	if c.VmConfig.ImageName == "" {
-		log.Println("No image_name assigned, setting to vm_name")
+		log.Println("No image_name defined, setting to vm_name")
 
 		c.VmConfig.ImageName = c.VmConfig.VMName
 	}

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -1009,10 +1009,10 @@ func (d *NutanixDriver) postRequest(ctx context.Context, url string, payload map
 	return resp, nil
 }
 
-func GetLatestOVAByName(ctx context.Context, entityType string, vmUUID string, conn *v3.Client) string {
+func GetLatestOVAByName(ctx context.Context, entityType string, name string, conn *v3.Client) string {
 	request := v3.GroupsGetEntitiesRequest{
 		EntityType:     &entityType,
-		FilterCriteria: fmt.Sprintf(`name==%s`, vmUUID),
+		FilterCriteria: fmt.Sprintf(`name==%s`, name),
 	}
 
 	var response *v3.GroupsGetEntitiesResponse

--- a/builder/nutanix/step_export_ova.go
+++ b/builder/nutanix/step_export_ova.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -57,15 +56,7 @@ func (s *StepExportOVA) Run(ctx context.Context, state multistep.StateBag) multi
 		toRead.Close()
 		f.Close()
 
-		// Check if size is OK
-		_, err := f.Stat()
-		if err != nil {
-			ui.Error("Image stat failed: " + err.Error())
-			state.Put("error", err)
-			return multistep.ActionHalt
-		}
-
-		name := s.OvaConfig.Name + "." + strings.ToLower(s.OvaConfig.Format)
+		name := s.OvaConfig.Name + ".ova"
 		err = os.Rename(tempDestinationPath, name)
 		if err != nil {
 			ui.Error("Failed to rename temporary file: " + err.Error())

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -46,7 +46,7 @@ These parameters allow to configure everything around image creation, from the t
 - `image_categories` ([]Category) - Assign Categories to the image.
 - `force_deregister` (bool) - Allow output image override if already exists.
 - `image_delete` (bool) - Delete image once build process is completed (default is false).
-- `image_export` (bool) - Export image in the current folder (default is false).
+- `image_export` (bool) - Export raw image in the current folder (default is false).
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).


### PR DESCRIPTION
This pull request includes updates to the Nutanix builder, focusing on improving clarity in logs, modifying method arguments for better consistency, and updating documentation. Additionally, some unused code has been removed, and a minor adjustment was made to the OVA export process.

### Documentation Updates:
* Updated the description of the `image_export` parameter in `.web-docs/components/builder/nutanix/README.md` and `docs/builders/nutanix.mdx` to specify that it exports a "raw image" instead of just an image. [[1]](diffhunk://#diff-785699748597f8f41fe692d5800dcfc25e10ad1de6880a8da23ee7c995ab0e34L40-R40) [[2]](diffhunk://#diff-e3bf31fea91fb90e9499f61d7e60f31d685ff58b8e730ef12fdc6f62c275bbdaL49-R49)

### Code Improvements:
* Improved log messages in `builder/nutanix/config.go` to use "defined" instead of "assigned" for better clarity.
* Changed the `GetLatestOVAByName` function in `builder/nutanix/driver.go` to accept `name` instead of `vmUUID` for the `FilterCriteria` parameter, ensuring consistency with its purpose.

### Code Simplification:
* Removed the unused `strings` import from `builder/nutanix/step_export_ova.go`.
* Simplified the OVA export logic in `builder/nutanix/step_export_ova.go` by removing unnecessary file size checks and hardcoding the file extension to `.ova`.