### PR TITLE
update ISO doc

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -101,6 +101,9 @@ Sample:
 - `image_type` (string) - "ISO_IMAGE".
 - `source_image_name` (string) - Name of the ISO image to mount.
 - `source_image_uuid` (string) - UUID of the ISO image to mount.
+- `source_image_uri` (string) - URI of the image used as ISO source (if image is not already on the cluster, it will download and store it before launching output image creation process).
+- `source_image_checksum` (string) - Checksum of the image used as ISO source (work only with `source_image_uri` and if image is not already present in the library).
+- `source_image_checksum_type` (string) - Type of checksum used for `source_image_checksum` (`sha256` or `sha1` ).
 - `source_image_delete` (bool) - Delete source image once build process is completed (default is false).
 - `source_image_force` (bool) - Always download and replace source image even if already exist (default is false).
 

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -110,6 +110,9 @@ Sample:
 - `image_type` (string) - "ISO_IMAGE".
 - `source_image_name` (string) - Name of the ISO image to mount.
 - `source_image_uuid` (string) - UUID of the ISO image to mount.
+- `source_image_uri` (string) - URI of the image used as ISO source (if image is not already on the cluster, it will download and store it before launching output image creation process).
+- `source_image_checksum` (string) - Checksum of the image used as ISO source (work only with `source_image_uri` and if image is not already present in the library).
+- `source_image_checksum_type` (string) - Type of checksum used for `source_image_checksum` (`sha256` or `sha1` ).
 - `source_image_delete` (bool) - Delete source image once build process is completed (default is false).
 - `source_image_force` (bool) - Always download and replace source image even if already exist (default is false).
 


### PR DESCRIPTION
This pull request updates the documentation for the Nutanix builder to include new options for handling ISO images. The changes add details about using a URI-based source image, along with checksum validation for enhanced image management.

### Documentation updates for Nutanix builder:

* Added descriptions for `source_image_uri`, `source_image_checksum`, and `source_image_checksum_type` options to explain their usage for downloading and validating ISO images.
