### PR TITLE
add core support

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -17,7 +17,8 @@ These parameters allow to define information about platform and temporary VM use
   - `nutanix_port` (number) - Port used for connection to Prism Central.
   - `nutanix_insecure` (bool) - Authorize connection to Prism Central without valid certificate.
   - `vm_name` (string) - Name of the temporary VM to create. If not specified a random `packer-*` name will be used.
-  - `cpu` (number) - Number of vCPU for temporary VM.
+  - `cpu` (number) - Number of vCPU for temporary VM (default is 1).
+  - `core` (number) - Number of cores per vCPU for temporary VM (default is 1).
   - `memory_mb` (number) - Size of vRAM for temporary VM (in megabytes).
   - `cd_files` (array of strings) - A list of files to place onto a CD that is attached when the VM is booted. This can include either files or directories; any directories will be copied onto the CD recursively, preserving directory structure hierarchy.
   - `cd_label` (string) - Label of this CD Drive.

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -103,6 +103,7 @@ type VmConfig struct {
 	ClusterUUID  string     `mapstructure:"cluster_uuid" json:"cluster_uuid" required:"false"`
 	ClusterName  string     `mapstructure:"cluster_name" json:"cluster_name" required:"false"`
 	CPU          int64      `mapstructure:"cpu" json:"cpu" required:"false"`
+	Core         int64      `mapstructure:"core" json:"core" required:"false"`
 	MemoryMB     int64      `mapstructure:"memory_mb" json:"memory_mb" required:"false"`
 	UserData     string     `mapstructure:"user_data" json:"user_data" required:"false"`
 	VMCategories []Category `mapstructure:"vm_categories" required:"false"`
@@ -145,6 +146,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	if c.CPU == 0 {
 		log.Println("No CPU configured, defaulting to '1'")
 		c.CPU = 1
+	}
+
+	if c.Core == 0 {
+		log.Println("No Core configured, defaulting to '1'")
+		c.Core = 1
 	}
 
 	if c.MemoryMB == 0 {

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -151,6 +151,7 @@ type FlatConfig struct {
 	ClusterUUID               *string           `mapstructure:"cluster_uuid" json:"cluster_uuid" required:"false" cty:"cluster_uuid" hcl:"cluster_uuid"`
 	ClusterName               *string           `mapstructure:"cluster_name" json:"cluster_name" required:"false" cty:"cluster_name" hcl:"cluster_name"`
 	CPU                       *int64            `mapstructure:"cpu" json:"cpu" required:"false" cty:"cpu" hcl:"cpu"`
+	Core                      *int64            `mapstructure:"core" json:"core" required:"false" cty:"core" hcl:"core"`
 	MemoryMB                  *int64            `mapstructure:"memory_mb" json:"memory_mb" required:"false" cty:"memory_mb" hcl:"memory_mb"`
 	UserData                  *string           `mapstructure:"user_data" json:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	VMCategories              []FlatCategory    `mapstructure:"vm_categories" required:"false" cty:"vm_categories" hcl:"vm_categories"`
@@ -263,6 +264,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"cluster_uuid":                 &hcldec.AttrSpec{Name: "cluster_uuid", Type: cty.String, Required: false},
 		"cluster_name":                 &hcldec.AttrSpec{Name: "cluster_name", Type: cty.String, Required: false},
 		"cpu":                          &hcldec.AttrSpec{Name: "cpu", Type: cty.Number, Required: false},
+		"core":                         &hcldec.AttrSpec{Name: "core", Type: cty.Number, Required: false},
 		"memory_mb":                    &hcldec.AttrSpec{Name: "memory_mb", Type: cty.Number, Required: false},
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"vm_categories":                &hcldec.BlockListSpec{TypeName: "vm_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
@@ -345,6 +347,7 @@ type FlatVmConfig struct {
 	ClusterUUID  *string        `mapstructure:"cluster_uuid" json:"cluster_uuid" required:"false" cty:"cluster_uuid" hcl:"cluster_uuid"`
 	ClusterName  *string        `mapstructure:"cluster_name" json:"cluster_name" required:"false" cty:"cluster_name" hcl:"cluster_name"`
 	CPU          *int64         `mapstructure:"cpu" json:"cpu" required:"false" cty:"cpu" hcl:"cpu"`
+	Core         *int64         `mapstructure:"core" json:"core" required:"false" cty:"core" hcl:"core"`
 	MemoryMB     *int64         `mapstructure:"memory_mb" json:"memory_mb" required:"false" cty:"memory_mb" hcl:"memory_mb"`
 	UserData     *string        `mapstructure:"user_data" json:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
 	VMCategories []FlatCategory `mapstructure:"vm_categories" required:"false" cty:"vm_categories" hcl:"vm_categories"`
@@ -375,6 +378,7 @@ func (*FlatVmConfig) HCL2Spec() map[string]hcldec.Spec {
 		"cluster_uuid":  &hcldec.AttrSpec{Name: "cluster_uuid", Type: cty.String, Required: false},
 		"cluster_name":  &hcldec.AttrSpec{Name: "cluster_name", Type: cty.String, Required: false},
 		"cpu":           &hcldec.AttrSpec{Name: "cpu", Type: cty.Number, Required: false},
+		"core":          &hcldec.AttrSpec{Name: "core", Type: cty.Number, Required: false},
 		"memory_mb":     &hcldec.AttrSpec{Name: "memory_mb", Type: cty.Number, Required: false},
 		"user_data":     &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 		"vm_categories": &hcldec.BlockListSpec{TypeName: "vm_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -533,6 +533,7 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vm VmConfig, state mu
 			Resources: &v3.VMResources{
 				GuestCustomization: guestCustomization,
 				NumSockets:         &vm.CPU,
+				NumVcpusPerSocket:  &vm.Core,
 				MemorySizeMib:      &vm.MemoryMB,
 				PowerState:         &powerStateOn,
 				DiskList:           DiskList,

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -26,7 +26,8 @@ These parameters allow to define information about platform and temporary VM use
   - `nutanix_port` (number) - Port used for connection to Prism Central.
   - `nutanix_insecure` (bool) - Authorize connection to Prism Central without valid certificate.
   - `vm_name` (string) - Name of the temporary VM to create. If not specified a random `packer-*` name will be used.
-  - `cpu` (number) - Number of vCPU for temporary VM.
+  - `cpu` (number) - Number of vCPU for temporary VM (default is 1).
+  - `core` (number) - Number of cores per vCPU for temporary VM (default is 1).
   - `memory_mb` (number) - Size of vRAM for temporary VM (in megabytes).
   - `cd_files` (array of strings) - A list of files to place onto a CD that is attached when the VM is booted. This can include either files or directories; any directories will be copied onto the CD recursively, preserving directory structure hierarchy.
   - `cd_label` (string) - Label of this CD Drive.


### PR DESCRIPTION
This pull request introduces support for specifying the number of cores per vCPU (`core`) for temporary VMs in the Nutanix builder. It adds the `core` parameter with a default value of 1, updates the configuration structs and validation logic, and ensures the parameter is properly documented.

Fix #257 

### Feature Addition: Support for `core` Parameter

* **Documentation Updates**:
  - Added the `core` parameter to the Nutanix builder documentation in `.web-docs/components/builder/nutanix/README.md` and `docs/builders/nutanix.mdx`, specifying its default value as 1. [[1]](diffhunk://#diff-785699748597f8f41fe692d5800dcfc25e10ad1de6880a8da23ee7c995ab0e34L20-R21) [[2]](diffhunk://#diff-e3bf31fea91fb90e9499f61d7e60f31d685ff58b8e730ef12fdc6f62c275bbdaL29-R30)

* **Configuration Changes**:
  - Added the `core` field to the `VmConfig`, `FlatConfig`, and `FlatVmConfig` structs in `builder/nutanix/config.go` and `builder/nutanix/config.hcl2spec.go`. [[1]](diffhunk://#diff-7839be77f2e6b64d78a48652f9529bf577a2d063f98779f9fb35e7756189dcf3R106) [[2]](diffhunk://#diff-690c8c0c69296bc15b08f247e16acfb80a08f1f965f38550405a5cbd988cae5bR154) [[3]](diffhunk://#diff-690c8c0c69296bc15b08f247e16acfb80a08f1f965f38550405a5cbd988cae5bR350)
  - Updated the HCL2 specification to include the `core` attribute. [[1]](diffhunk://#diff-690c8c0c69296bc15b08f247e16acfb80a08f1f965f38550405a5cbd988cae5bR267) [[2]](diffhunk://#diff-690c8c0c69296bc15b08f247e16acfb80a08f1f965f38550405a5cbd988cae5bR381)

* **Default Value Handling**:
  - Updated the `Prepare` method in `builder/nutanix/config.go` to set the default value of `core` to 1 if not provided.

* **Driver Update**:
  - Modified the Nutanix driver in `builder/nutanix/driver.go` to pass the `core` parameter (`NumVcpusPerSocket`) when creating a VM.