### PR TITLE
Add `vm_retain` config option to prevent VM deletion

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -42,6 +42,7 @@ These parameters allow to configure everything around image creation, from the t
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).
+- `vm_retain` (bool) - Retain the temporary VM after build process is completed (default is false).
 - `communicator` (string) - Protocol used for Packer connection (ex "winrm" or "ssh"). Default is : "ssh".
 
 ### Dedicated to Linux

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	ImageDelete                    bool       `mapstructure:"image_delete" json:"image_delete" required:"false"`
 	ImageExport                    bool       `mapstructure:"image_export" json:"image_export" required:"false"`
 	VmForceDelete                  bool       `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false"`
+	VmRetain                       bool       `mapstructure:"vm_retain" json:"vm_retain" required:"false"`
 
 	ctx interpolate.Context
 }

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -165,6 +165,7 @@ type FlatConfig struct {
 	ImageDelete               *bool             `mapstructure:"image_delete" json:"image_delete" required:"false" cty:"image_delete" hcl:"image_delete"`
 	ImageExport               *bool             `mapstructure:"image_export" json:"image_export" required:"false" cty:"image_export" hcl:"image_export"`
 	VmForceDelete             *bool             `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false" cty:"vm_force_delete" hcl:"vm_force_delete"`
+	VmRetain                  *bool             `mapstructure:"vm_retain" json:"vm_retain" required:"false" cty:"vm_retain" hcl:"vm_retain"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -278,6 +279,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_delete":                 &hcldec.AttrSpec{Name: "image_delete", Type: cty.Bool, Required: false},
 		"image_export":                 &hcldec.AttrSpec{Name: "image_export", Type: cty.Bool, Required: false},
 		"vm_force_delete":              &hcldec.AttrSpec{Name: "vm_force_delete", Type: cty.Bool, Required: false},
+		"vm_retain":                    &hcldec.AttrSpec{Name: "vm_retain", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/nutanix/step_build_vm.go
+++ b/builder/nutanix/step_build_vm.go
@@ -115,6 +115,9 @@ func (s *stepBuildVM) Cleanup(state multistep.StateBag) {
 		return
 	} else if config.VmForceDelete && cancelled || halted {
 		ui.Say("Force deleting virtual machine...")
+	} else if config.VmRetain {
+		ui.Say("Retaining virtual machine...")
+		return
 	} else {
 		ui.Say("Deleting virtual machine...")
 	}

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -51,6 +51,7 @@ These parameters allow to configure everything around image creation, from the t
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).
+- `vm_retain` (bool) - Retain the temporary VM after build process is completed (default is false).
 - `communicator` (string) - Protocol used for Packer connection (ex "winrm" or "ssh"). Default is : "ssh".
 
 ### Dedicated to Linux


### PR DESCRIPTION
# Add `vm_retain` config option to prevent VM deletion

## Summary
Introduces a new configuration option, `vm_retain`, which when set to `true`, prevents the virtual machine from being deleted at the end of the packer process.

Fix #182 

## Motivation
This feature provides users with control over VM lifecycle, allowing them to retain the VM after the process finishes for debugging, inspection, or other purposes.

## Details
- Adds `vm_retain` boolean flag to the JSON config schema.
- When `vm_retain` is `true`, the VM is preserved and not deleted at process completion.
- Default behavior remains unchanged (VM deleted unless `vm_retain` is explicitly set).
