### PR TITLE
Add `image_skip` option to skip image creation step

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -38,6 +38,7 @@ These parameters allow to configure everything around image creation, from the t
 - `image_categories` ([]Category) - Assign Categories to the image.
 - `force_deregister` (bool) - Allow output image override if already exists.
 - `image_delete` (bool) - Delete image once build process is completed (default is false).
+- `image_skip` (bool) - Skip image creation (default is false).
 - `image_export` (bool) - Export raw image in the current folder (default is false).
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).

--- a/builder/nutanix/builder.go
+++ b/builder/nutanix/builder.go
@@ -81,9 +81,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Command: b.config.ShutdownCommand,
 			Timeout: b.config.ShutdownTimeout,
 		},
-		&stepCopyImage{
+	}
+
+	if !b.config.ImageSkip {
+		steps = append(steps, &stepCreateImage{
 			Config: &b.config,
-		},
+		})
 	}
 
 	if b.config.OvaConfig.Create {

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	ForceDeregister                bool       `mapstructure:"force_deregister" json:"force_deregister" required:"false"`
 	ImageDescription               string     `mapstructure:"image_description" json:"image_description" required:"false"`
 	ImageCategories                []Category `mapstructure:"image_categories" required:"false"`
+	ImageSkip                      bool       `mapstructure:"image_skip" json:"image_skip" required:"false"`
 	ImageDelete                    bool       `mapstructure:"image_delete" json:"image_delete" required:"false"`
 	ImageExport                    bool       `mapstructure:"image_export" json:"image_export" required:"false"`
 	VmForceDelete                  bool       `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false"`

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -162,6 +162,7 @@ type FlatConfig struct {
 	ForceDeregister           *bool             `mapstructure:"force_deregister" json:"force_deregister" required:"false" cty:"force_deregister" hcl:"force_deregister"`
 	ImageDescription          *string           `mapstructure:"image_description" json:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageCategories           []FlatCategory    `mapstructure:"image_categories" required:"false" cty:"image_categories" hcl:"image_categories"`
+	ImageSkip                 *bool             `mapstructure:"image_skip" json:"image_skip" required:"false" cty:"image_skip" hcl:"image_skip"`
 	ImageDelete               *bool             `mapstructure:"image_delete" json:"image_delete" required:"false" cty:"image_delete" hcl:"image_delete"`
 	ImageExport               *bool             `mapstructure:"image_export" json:"image_export" required:"false" cty:"image_export" hcl:"image_export"`
 	VmForceDelete             *bool             `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false" cty:"vm_force_delete" hcl:"vm_force_delete"`
@@ -276,6 +277,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"force_deregister":             &hcldec.AttrSpec{Name: "force_deregister", Type: cty.Bool, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_categories":             &hcldec.BlockListSpec{TypeName: "image_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
+		"image_skip":                   &hcldec.AttrSpec{Name: "image_skip", Type: cty.Bool, Required: false},
 		"image_delete":                 &hcldec.AttrSpec{Name: "image_delete", Type: cty.Bool, Required: false},
 		"image_export":                 &hcldec.AttrSpec{Name: "image_export", Type: cty.Bool, Required: false},
 		"vm_force_delete":              &hcldec.AttrSpec{Name: "vm_force_delete", Type: cty.Bool, Required: false},

--- a/builder/nutanix/step_copy_image.go
+++ b/builder/nutanix/step_copy_image.go
@@ -19,11 +19,11 @@ type diskArtefact struct {
 	size int64
 }
 
-type stepCopyImage struct {
+type stepCreateImage struct {
 	Config *Config
 }
 
-func (s *stepCopyImage) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	vmUUID := state.Get("vm_uuid").(string)
 	d := state.Get("driver").(Driver)
@@ -75,7 +75,7 @@ func (s *stepCopyImage) Run(ctx context.Context, state multistep.StateBag) multi
 	return multistep.ActionContinue
 }
 
-func (s *stepCopyImage) Cleanup(state multistep.StateBag) {
+func (s *stepCreateImage) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packer.Ui)
 	d := state.Get("driver").(Driver)
 	ctx, ok := state.Get("ctx").(context.Context)

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -47,6 +47,7 @@ These parameters allow to configure everything around image creation, from the t
 - `image_categories` ([]Category) - Assign Categories to the image.
 - `force_deregister` (bool) - Allow output image override if already exists.
 - `image_delete` (bool) - Delete image once build process is completed (default is false).
+- `image_skip` (bool) - Skip image creation (default is false).
 - `image_export` (bool) - Export raw image in the current folder (default is false).
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).


### PR DESCRIPTION
# Add `image_skip` config option to skip image creation process

## Summary
Introduces a new configuration option, `image_skip`, which when set to `true`, skips the creation of the image during the packer  process.

Fix #182 

## Motivation
This feature gives users control to avoid unnecessary image creation when it’s not needed, saving time and resources during the workflow.

## Details
- Adds `image_skip` boolean flag to the JSON config schema.
- When `image_skip` is `true`, the image creation step is bypassed.
- Default behavior remains unchanged (image is created unless `image_skip` is explicitly set).

