### PR TITLE
add cleaning cdrom feature

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -136,6 +136,22 @@ Sample:
   }
 ```
 
+## VM Clean
+
+Use `vm_clean{}` entry to configure VM cleaning options. This section allows you to clean up the temporary VM after the image creation process is completed.
+It can be useful to remove unnecessary components or reset the VM to a clean state before creating a template or exporting an OVA.
+
+All parameters of this `vm_clean` section are described below.
+
+- `cdrom` (bool) - Remove all CD-ROMs from the VM (default is false).
+
+Sample:
+```hcl
+  vm_clean {
+      cdrom = true
+  }
+```
+
 ## Template configuration
 
 Use `template{}` entry to create a template from the temporary VM.

--- a/builder/nutanix/builder.go
+++ b/builder/nutanix/builder.go
@@ -83,6 +83,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 	}
 
+	if b.config.Clean.Cdrom {
+		steps = append(steps, &stepCleanVM{
+			Config: &b.config,
+		})
+	}
+
 	if b.config.TemplateConfig.Create {
 		steps = append(steps, &stepCreateTemplate{
 			Config: &b.config,

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -1,4 +1,4 @@
-//go:generate packer-sdc mapstructure-to-hcl2 -type Config,Category,ClusterConfig,VmConfig,VmDisk,VmNIC,GPU,OvaConfig,TemplateConfig,VTPM
+//go:generate packer-sdc mapstructure-to-hcl2 -type Config,Category,ClusterConfig,VmConfig,VmDisk,VmNIC,GPU,OvaConfig,TemplateConfig,VTPM,VmClean
 
 package nutanix
 
@@ -122,6 +122,11 @@ type VmConfig struct {
 	Project                string     `mapstructure:"project" required:"false"`
 	GPU                    []GPU      `mapstructure:"gpu" required:"false"`
 	SerialPort             bool       `mapstructure:"serialport" json:"serialport" required:"false"`
+	Clean                  VmClean    `mapstructure:"vm_clean" json:"vm_clean" required:"false"`
+}
+
+type VmClean struct {
+	Cdrom bool `mapstructure:"cdrom" json:"cdrom" required:"false"`
 }
 
 type OvaConfig struct {

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -160,6 +160,7 @@ type FlatConfig struct {
 	Project                   *string             `mapstructure:"project" required:"false" cty:"project" hcl:"project"`
 	GPU                       []FlatGPU           `mapstructure:"gpu" required:"false" cty:"gpu" hcl:"gpu"`
 	SerialPort                *bool               `mapstructure:"serialport" json:"serialport" required:"false" cty:"serialport" hcl:"serialport"`
+	Clean                     *FlatVmClean        `mapstructure:"vm_clean" json:"vm_clean" required:"false" cty:"vm_clean" hcl:"vm_clean"`
 	OvaConfig                 *FlatOvaConfig      `mapstructure:"ova" required:"false" cty:"ova" hcl:"ova"`
 	TemplateConfig            *FlatTemplateConfig `mapstructure:"template" required:"false" cty:"template" hcl:"template"`
 	ForceDeregister           *bool               `mapstructure:"force_deregister" json:"force_deregister" required:"false" cty:"force_deregister" hcl:"force_deregister"`
@@ -278,6 +279,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"project":                      &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"gpu":                          &hcldec.BlockListSpec{TypeName: "gpu", Nested: hcldec.ObjectSpec((*FlatGPU)(nil).HCL2Spec())},
 		"serialport":                   &hcldec.AttrSpec{Name: "serialport", Type: cty.Bool, Required: false},
+		"vm_clean":                     &hcldec.BlockSpec{TypeName: "vm_clean", Nested: hcldec.ObjectSpec((*FlatVmClean)(nil).HCL2Spec())},
 		"ova":                          &hcldec.BlockSpec{TypeName: "ova", Nested: hcldec.ObjectSpec((*FlatOvaConfig)(nil).HCL2Spec())},
 		"template":                     &hcldec.BlockSpec{TypeName: "template", Nested: hcldec.ObjectSpec((*FlatTemplateConfig)(nil).HCL2Spec())},
 		"force_deregister":             &hcldec.AttrSpec{Name: "force_deregister", Type: cty.Bool, Required: false},
@@ -394,6 +396,29 @@ func (*FlatVTPM) HCL2Spec() map[string]hcldec.Spec {
 	return s
 }
 
+// FlatVmClean is an auto-generated flat version of VmClean.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatVmClean struct {
+	Cdrom *bool `mapstructure:"cdrom" json:"cdrom" required:"false" cty:"cdrom" hcl:"cdrom"`
+}
+
+// FlatMapstructure returns a new FlatVmClean.
+// FlatVmClean is an auto-generated flat version of VmClean.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*VmClean) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatVmClean)
+}
+
+// HCL2Spec returns the hcl spec of a VmClean.
+// This spec is used by HCL to read the fields of VmClean.
+// The decoded values from this spec will then be applied to a FlatVmClean.
+func (*FlatVmClean) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"cdrom": &hcldec.AttrSpec{Name: "cdrom", Type: cty.Bool, Required: false},
+	}
+	return s
+}
+
 // FlatVmConfig is an auto-generated flat version of VmConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatVmConfig struct {
@@ -416,6 +441,7 @@ type FlatVmConfig struct {
 	Project                *string        `mapstructure:"project" required:"false" cty:"project" hcl:"project"`
 	GPU                    []FlatGPU      `mapstructure:"gpu" required:"false" cty:"gpu" hcl:"gpu"`
 	SerialPort             *bool          `mapstructure:"serialport" json:"serialport" required:"false" cty:"serialport" hcl:"serialport"`
+	Clean                  *FlatVmClean   `mapstructure:"vm_clean" json:"vm_clean" required:"false" cty:"vm_clean" hcl:"vm_clean"`
 }
 
 // FlatMapstructure returns a new FlatVmConfig.
@@ -449,6 +475,7 @@ func (*FlatVmConfig) HCL2Spec() map[string]hcldec.Spec {
 		"project":                 &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"gpu":                     &hcldec.BlockListSpec{TypeName: "gpu", Nested: hcldec.ObjectSpec((*FlatGPU)(nil).HCL2Spec())},
 		"serialport":              &hcldec.AttrSpec{Name: "serialport", Type: cty.Bool, Required: false},
+		"vm_clean":                &hcldec.BlockSpec{TypeName: "vm_clean", Nested: hcldec.ObjectSpec((*FlatVmClean)(nil).HCL2Spec())},
 	}
 	return s
 }

--- a/builder/nutanix/step_clean_vm.go
+++ b/builder/nutanix/step_clean_vm.go
@@ -1,0 +1,57 @@
+package nutanix
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+	v3 "github.com/nutanix-cloud-native/prism-go-client/v3"
+)
+
+// stepCleanVM is the default struct which contains the step's information
+type stepCleanVM struct {
+	Config *Config
+}
+
+// Run is the primary function to clean up the VM
+func (s *stepCleanVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	// Update UI
+	ui := state.Get("ui").(packer.Ui)
+	d := state.Get("driver").(Driver)
+	vmUUID := state.Get("vm_uuid").(string)
+
+	if !s.Config.Clean.Cdrom {
+		log.Printf("No vm cleaning requested, skipping step.")
+		return multistep.ActionContinue
+	}
+
+	vmResp, err := d.GetVM(ctx, vmUUID)
+	if err != nil {
+		ui.Error("Error retrieving virtual machine: " + err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Prepare VM update request
+	request := &v3.VMIntentInput{}
+	request.Spec = vmResp.nutanix.Spec
+	request.Metadata = vmResp.nutanix.Metadata
+
+	if s.Config.Clean.Cdrom {
+		ui.Message("Cleaning up CD-ROM in virtual machine...")
+		d.CleanCD(ctx, request)
+	}
+
+	_, err = d.UpdateVM(ctx, vmUUID, request)
+	if err != nil {
+		ui.Error("Error updating virtual machine: " + err.Error())
+		return multistep.ActionHalt
+	}
+
+	ui.Message("Virtual machine cleaned successfully.")
+	return multistep.ActionContinue
+}
+
+func (s *stepCleanVM) Cleanup(state multistep.StateBag) {
+	// No cleanup needed for VM cleaning step
+}

--- a/builder/nutanix/step_shutdown_vm.go
+++ b/builder/nutanix/step_shutdown_vm.go
@@ -88,6 +88,7 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 	}
 
 	log.Println("VM shut down.")
+
 	return multistep.ActionContinue
 }
 

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -145,6 +145,22 @@ Sample:
   }
 ```
 
+## VM Clean
+
+Use `vm_clean{}` entry to configure VM cleaning options. This section allows you to clean up the temporary VM after the image creation process is completed.
+It can be useful to remove unnecessary components or reset the VM to a clean state before creating a template or exporting an OVA.
+
+All parameters of this `vm_clean` section are described below.
+
+- `cdrom` (bool) - Remove all CD-ROMs from the VM (default is false).
+
+Sample:
+```hcl
+  vm_clean {
+      cdrom = true
+  }
+```
+
 ## Template configuration
 
 Use `template{}` entry to create a template from the temporary VM.

--- a/example/scripts/ks.cfg
+++ b/example/scripts/ks.cfg
@@ -23,7 +23,8 @@ lang en-US.UTF-8
 network --bootproto=dhcp --ipv6=auto --hostname=centos-ks.local --activate
 
 # Root password (remember that plaintext only for information purposes)
-rootpw --plaintext packer
+rootpw --plaintext --allow-ssh packer
+
 
 # Setting up firewall and enabling SSH for remote management
 firewall --enabled --service=ssh


### PR DESCRIPTION
This pull request introduces a new feature for cleaning up virtual machines (VMs) in the Nutanix builder, along with the associated configuration and implementation changes. The most important updates include the addition of a `vm_clean` configuration block, the implementation of VM cleanup logic to remove CD-ROMs, and updates to the documentation and example files.

### New VM Cleanup Feature:

* **Configuration Updates**:
  - Added a new `vm_clean` block in the Nutanix builder configuration, allowing users to specify cleanup options such as removing CD-ROMs from VMs. 
  - Introduced a `VmClean` struct to define the cleanup options and integrated it into the `VmConfig` and `FlatVmConfig` structures.

* **Implementation of Cleanup Logic**:
  - Added a new step, `stepCleanVM`, to handle VM cleanup during the build process. This step checks for the `cdrom` option and removes CD-ROM devices if specified. 
  - Extended the Nutanix driver interface with methods for updating VMs and cleaning CD-ROMs. 

### Documentation and Examples:

* **Documentation Updates**:
  - Updated the Nutanix builder README and documentation files to include details about the new `vm_clean` block and its parameters. 

* **Example Updates**:
  - Modified the example Kickstart file to include the `--allow-ssh` option for the root password, fixing an issue with recent versions.