### PR TITLE
storage container uuid for disk

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -90,6 +90,8 @@ All parameters of this `vm_disks` section are described below.
 ### Disk 
 - `image_type` (string) - "DISK".
 - `disk_size_gb` (number) - size of th disk (in gigabytes).
+- `storage_container_uuid` (string) - UUID of the storage container where the disk image will be created. If not specified, the default storage container for the cluster will be used.
+
 
 Sample:
 ```hcl

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -96,6 +96,7 @@ type VmDisk struct {
 	SourceImageDelete       bool   `mapstructure:"source_image_delete" json:"source_image_delete" required:"false"`
 	SourceImageForce        bool   `mapstructure:"source_image_force" json:"source_image_force" required:"false"`
 	DiskSizeGB              int64  `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false"`
+	StorageContainerUUID    string `mapstructure:"storage_container_uuid" json:"storage_container_uuid" required:"false"`
 }
 
 type VmNIC struct {
@@ -348,6 +349,12 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		if disk.SourceImageChecksumType != "" && disk.SourceImageChecksum == "" {
 			log.Printf("disk %d: No checksum set despite checksum type configure\n", index)
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("disk %d: no source_image_checksum set despite checksum_type configured", index))
+		}
+
+		// Validate storage container defined only with disk type
+		if (disk.StorageContainerUUID != "") && disk.ImageType != "DISK" {
+			log.Printf("disk %d: Storage container UUID can be set only with DISK image type\n", index)
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("disk %d: storage_container_uuid can be set only with DISK image type", index))
 		}
 
 	}

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -492,6 +492,7 @@ type FlatVmDisk struct {
 	SourceImageDelete       *bool   `mapstructure:"source_image_delete" json:"source_image_delete" required:"false" cty:"source_image_delete" hcl:"source_image_delete"`
 	SourceImageForce        *bool   `mapstructure:"source_image_force" json:"source_image_force" required:"false" cty:"source_image_force" hcl:"source_image_force"`
 	DiskSizeGB              *int64  `mapstructure:"disk_size_gb" json:"disk_size_gb" required:"false" cty:"disk_size_gb" hcl:"disk_size_gb"`
+	StorageContainerUUID    *string `mapstructure:"storage_container_uuid" json:"storage_container_uuid" required:"false" cty:"storage_container_uuid" hcl:"storage_container_uuid"`
 }
 
 // FlatMapstructure returns a new FlatVmDisk.
@@ -515,6 +516,7 @@ func (*FlatVmDisk) HCL2Spec() map[string]hcldec.Spec {
 		"source_image_delete":        &hcldec.AttrSpec{Name: "source_image_delete", Type: cty.Bool, Required: false},
 		"source_image_force":         &hcldec.AttrSpec{Name: "source_image_force", Type: cty.Bool, Required: false},
 		"disk_size_gb":               &hcldec.AttrSpec{Name: "disk_size_gb", Type: cty.Number, Required: false},
+		"storage_container_uuid":     &hcldec.AttrSpec{Name: "storage_container_uuid", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -421,6 +421,17 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vm VmConfig, state mu
 				},
 				DiskSizeMib: &DiskSizeMib,
 			}
+
+			if disk.StorageContainerUUID != "" {
+				newDisk.StorageConfig = &v3.VMStorageConfig{
+					StorageContainerReference: &v3.StorageContainerReference{
+						Kind: "storage_container",
+						UUID: disk.StorageContainerUUID,
+					},
+				}
+
+			}
+
 			DiskList = append(DiskList, &newDisk)
 			SCSIindex++
 		}

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -99,6 +99,8 @@ All parameters of this `vm_disks` section are described below.
 ### Disk 
 - `image_type` (string) - "DISK".
 - `disk_size_gb` (number) - size of th disk (in gigabytes).
+- `storage_container_uuid` (string) - UUID of the storage container where the disk image will be created. If not specified, the default storage container for the cluster will be used.
+
 
 Sample:
 ```hcl


### PR DESCRIPTION
This pull request introduces support for specifying a `storage_container_uuid` for Nutanix virtual machine disks, allowing users to define the storage container where disk images will be created. The changes include updates to the configuration schema, validation logic, and documentation.

Fix #62 

### Configuration Updates:
* Added a new `StorageContainerUUID` field to the `VmDisk` and `FlatVmDisk` structs in `builder/nutanix/config.go` and `builder/nutanix/config.hcl2spec.go`, respectively. This field allows users to specify the UUID of the storage container.
* Updated the HCL2 specification to include the `storage_container_uuid` attribute, ensuring it is recognized in configuration files.

### Validation Enhancements:
* Added validation logic in the `Prepare` method to ensure that the `storage_container_uuid` is only set when the `image_type` is "DISK". If this condition is not met, an error is logged and appended to the validation errors.

### Driver Implementation:
* Updated the Nutanix driver to include the `storage_container_uuid` in the disk creation request. If the field is set, it adds the appropriate storage configuration to the request.

### Documentation Updates:
* Updated the documentation in `.web-docs/components/builder/nutanix/README.md` and `docs/builders/nutanix.mdx` to describe the new `storage_container_uuid` parameter, including its purpose and default behavior when not specified. 