### PR TITLE
ignore prism central cluster

### DIFF
--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -111,7 +111,7 @@ func findClusterByName(ctx context.Context, conn *v3.Client, name string) (*v3.C
 
 	found := make([]*v3.ClusterIntentResponse, 0)
 	for _, v := range entities {
-		if strings.EqualFold(*v.Status.Name, name) {
+		if strings.EqualFold(*v.Status.Name, name) && !IsPrismCentral(v) {
 			found = append(found, &v3.ClusterIntentResponse{
 				Status:     v.Status,
 				Spec:       v.Spec,

--- a/builder/nutanix/utils.go
+++ b/builder/nutanix/utils.go
@@ -1,6 +1,8 @@
 package nutanix
 
 import (
+	"strings"
+
 	v3 "github.com/nutanix-cloud-native/prism-go-client/v3"
 )
 
@@ -18,4 +20,26 @@ func BuildReferenceValue(uuid, kind string) *v3.ReferenceValues {
 		Kind: kind,
 		UUID: uuid,
 	}
+}
+
+const prismCentralService = "PRISM_CENTRAL"
+
+// IsPrismCentral checks if the cluster is a prism central instance or not
+// by checking if the service running on the cluster is PRISM_CENTRAL
+func IsPrismCentral(cluster *v3.ClusterIntentResponse) bool {
+	if cluster.Status == nil ||
+		cluster.Status.Resources == nil ||
+		cluster.Status.Resources.Config == nil ||
+		cluster.Status.Resources.Config.ServiceList == nil ||
+		len(cluster.Status.Resources.Config.ServiceList) == 0 {
+		return false
+	}
+
+	for _, service := range cluster.Status.Resources.Config.ServiceList {
+		if service != nil && strings.EqualFold(*service, prismCentralService) {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
This pull request introduces a new utility function to identify Prism Central clusters and updates the cluster filtering logic in `findClusterByName` to exclude such clusters. Additionally, it includes a minor import adjustment to support the new functionality.

Fix #244

### Changes to cluster filtering:

* [`builder/nutanix/driver.go`]: Updated the `findClusterByName` function to exclude clusters identified as Prism Central by adding a check using the new `IsPrismCentral` function.

### New utility function:

* [`builder/nutanix/utils.go`]: Added the `IsPrismCentral` function, which determines if a cluster is a Prism Central instance by evaluating its service list. This includes defining a new constant `prismCentralService` to represent the "PRISM_CENTRAL" service.

### Import adjustments:

* [`builder/nutanix/utils.go`]: Added the `"strings"` package import to support case-insensitive string comparisons in the new utility function.