### PR TITLE
disable_stop_instance feature

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -62,7 +62,9 @@ These parameters allow to configure everything around image creation, from the t
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).
 - `vm_retain` (bool) - Retain the temporary VM after build process is completed (default is false).
-- `communicator` (string) - Protocol used for Packer connection (ex "winrm" or "ssh"). Default is : "ssh".
+- `disable_stop_instance` (bool) - By default, Packer stops the build instance after provisioning is complete. Setting this option to `true` prevents Packer from stopping the instance itself, expecting your final provisioner to handle stopping the instance instead.
+  Keep in mind, Packer will still wait for the instance to stop; if your provisioner does not stop it, the build process will eventually time out.
+- `communicator` (string) - Protocol used for Packer connection ("winrm", "ssh" or "none"). Default is : "ssh".
 
 ### Dedicated to Linux
 - `user_data` (string) - cloud-init content base64 encoded.

--- a/builder/nutanix/builder.go
+++ b/builder/nutanix/builder.go
@@ -78,8 +78,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		new(commonsteps.StepProvision),
 		&StepShutdown{
-			Command: b.config.ShutdownCommand,
-			Timeout: b.config.ShutdownTimeout,
+			Command:             b.config.ShutdownCommand,
+			Timeout:             b.config.ShutdownTimeout,
+			DisableStopInstance: b.config.DisableStopInstance,
 		},
 	}
 

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	ImageExport                    bool           `mapstructure:"image_export" json:"image_export" required:"false"`
 	VmForceDelete                  bool           `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false"`
 	VmRetain                       bool           `mapstructure:"vm_retain" json:"vm_retain" required:"false"`
+	DisableStopInstance            bool           `mapstructure:"disable_stop_instance" required:"false"`
 
 	ctx interpolate.Context
 }

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -171,6 +171,7 @@ type FlatConfig struct {
 	ImageExport               *bool               `mapstructure:"image_export" json:"image_export" required:"false" cty:"image_export" hcl:"image_export"`
 	VmForceDelete             *bool               `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false" cty:"vm_force_delete" hcl:"vm_force_delete"`
 	VmRetain                  *bool               `mapstructure:"vm_retain" json:"vm_retain" required:"false" cty:"vm_retain" hcl:"vm_retain"`
+	DisableStopInstance       *bool               `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -290,6 +291,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_export":                 &hcldec.AttrSpec{Name: "image_export", Type: cty.Bool, Required: false},
 		"vm_force_delete":              &hcldec.AttrSpec{Name: "vm_force_delete", Type: cty.Bool, Required: false},
 		"vm_retain":                    &hcldec.AttrSpec{Name: "vm_retain", Type: cty.Bool, Required: false},
+		"disable_stop_instance":        &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -71,7 +71,9 @@ These parameters allow to configure everything around image creation, from the t
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).
 - `vm_retain` (bool) - Retain the temporary VM after build process is completed (default is false).
-- `communicator` (string) - Protocol used for Packer connection (ex "winrm" or "ssh"). Default is : "ssh".
+- `disable_stop_instance` (bool) - By default, Packer stops the build instance after provisioning is complete. Setting this option to `true` prevents Packer from stopping the instance itself, expecting your final provisioner to handle stopping the instance instead.
+  Keep in mind, Packer will still wait for the instance to stop; if your provisioner does not stop it, the build process will eventually time out.
+- `communicator` (string) - Protocol used for Packer connection ("winrm", "ssh" or "none"). Default is : "ssh".
 
 ### Dedicated to Linux
 - `user_data` (string) - cloud-init content base64 encoded.


### PR DESCRIPTION
This pull request introduces a new configuration option, `disable_stop_instance`, to the Nutanix builder in Packer. This option provides users with more control over the instance shutdown process during image building. The changes include updates to the configuration, documentation, and the shutdown logic.

Fix #206 

### New Feature: `disable_stop_instance` Configuration

* **Documentation Updates**:
  - Added the `disable_stop_instance` option to the Nutanix builder documentation in `.web-docs/components/builder/nutanix/README.md` and `docs/builders/nutanix.mdx`. This option prevents Packer from stopping the instance after provisioning, allowing the final provisioner to handle the shutdown instead. 

* **Configuration Changes**:
  - Introduced a new `DisableStopInstance` field in the `Config` and `FlatConfig` structs in `builder/nutanix/config.go` and `builder/nutanix/config.hcl2spec.go`. Updated the HCL2 specification to include this new field.

* **Shutdown Logic Updates**:
  - Modified the `StepShutdown` struct and its `Run` method in `builder/nutanix/step_shutdown_vm.go` to respect the `disable_stop_instance` setting. If enabled, Packer logs a message and skips the automatic instance stop, requiring manual intervention.
* **Builder Integration**:
  - Integrated the `DisableStopInstance` field into the `Run` method of the Nutanix builder in `builder/nutanix/builder.go`, ensuring the shutdown step respects the new configuration.