### PR TITLE
fix image export and artifact creation ordering

### DIFF
--- a/builder/nutanix/builder.go
+++ b/builder/nutanix/builder.go
@@ -90,14 +90,21 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		})
 	}
 
-	if b.config.TemplateConfig.Create {
-		steps = append(steps, &stepCreateTemplate{
+	if !b.config.ImageSkip {
+		steps = append(steps, &stepCreateImage{
 			Config: &b.config,
 		})
 	}
 
-	if !b.config.ImageSkip {
-		steps = append(steps, &stepCreateImage{
+	if b.config.ImageExport {
+		steps = append(steps, &stepExportImage{
+			VMName:    b.config.VMName,
+			ImageName: b.config.VmConfig.ImageName,
+		})
+	}
+
+	if b.config.TemplateConfig.Create {
+		steps = append(steps, &stepCreateTemplate{
 			Config: &b.config,
 		})
 	}
@@ -113,13 +120,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		steps = append(steps, &StepExportOVA{
 			VMName:    b.config.VMName,
 			OvaConfig: b.config.OvaConfig,
-		})
-	}
-
-	if b.config.ImageExport {
-		steps = append(steps, &stepExportImage{
-			VMName:    b.config.VMName,
-			ImageName: b.config.VmConfig.ImageName,
 		})
 	}
 

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -223,6 +223,13 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		c.OvaConfig.Create = true
 	}
 
+	// When trying to export image, it should always be created
+	if c.ImageSkip && c.ImageExport {
+		log.Println("Setting image_skip to 'false' and image_delete to 'true', because image_export is 'true'")
+		c.ImageSkip = false
+		c.ImageDelete = true
+	}
+
 	// Set OVA format if not provided
 	if c.OvaConfig.Create && c.OvaConfig.Format == "" {
 		c.OvaConfig.Format = "vmdk"


### PR DESCRIPTION
This pull request introduces changes to the Nutanix builder to enhance the handling of image creation, export, and template creation logic. The most important updates include reordering and refining the steps in the `Run` method and adding logic to ensure proper configuration when exporting images.

### Updates to the build steps:

* Reordered the steps in the `Run` method in `builder/nutanix/builder.go`:
  - The `stepCreateImage` is now conditioned on `!b.config.ImageSkip`.
  - The `stepExportImage` is added when `b.config.ImageExport` is true, and it is placed before the `stepCreateTemplate`.
  - Removed redundant `stepExportImage` logic at the end of the method.

### Configuration adjustments:

* Added logic in `builder/nutanix/config.go` to ensure that when `ImageExport` is enabled, `ImageSkip` is set to `false` and `ImageDelete` is set to `true`. This ensures the image is created and deleted after export to maintain consistency.