### PR TITLE
ui.Message is deprecated: Use `Say` instead

### DIFF
--- a/builder/nutanix/step_build_vm.go
+++ b/builder/nutanix/step_build_vm.go
@@ -59,7 +59,7 @@ func (s *stepBuildVM) Run(ctx context.Context, state multistep.StateBag) multist
 				state.Put("error", err)
 				return multistep.ActionHalt
 			}
-			ui.Message(fmt.Sprintf("Disk %d uploaded: %s", i, *uploadedImage.image.Spec.Name))
+			ui.Say(fmt.Sprintf("Disk %d uploaded: %s", i, *uploadedImage.image.Spec.Name))
 			state.Put(fmt.Sprintf("disk_%d_uuid", i), *uploadedImage.image.Metadata.UUID)
 			config.VmConfig.VmDisks[i].SourceImageUUID = *uploadedImage.image.Metadata.UUID
 		} else {
@@ -86,7 +86,7 @@ func (s *stepBuildVM) Run(ctx context.Context, state multistep.StateBag) multist
 		return multistep.ActionHalt
 	}
 	log.Printf("Nutanix VM UUID: %s", *vmInstance.nutanix.Metadata.UUID)
-	ui.Message(fmt.Sprintf("Virtual machine %s created", config.VMName))
+	ui.Say(fmt.Sprintf("Virtual machine %s created", config.VMName))
 	state.Put("destroy_vm", true)
 	state.Put("vm_uuid", *vmInstance.nutanix.Metadata.UUID)
 	state.Put("cluster_uuid", *vmInstance.nutanix.Spec.ClusterReference.UUID)
@@ -116,7 +116,7 @@ func (s *stepBuildVM) Cleanup(state multistep.StateBag) {
 			ui.Error("An error occurred while deleting CD disk")
 			log.Println(err)
 		}
-		ui.Message("Temporary CD disk successfully deleted")
+		ui.Say("Temporary CD disk successfully deleted")
 	}
 
 	imageToDelete := state.Get("image_to_delete")
@@ -128,7 +128,7 @@ func (s *stepBuildVM) Cleanup(state multistep.StateBag) {
 			ui.Error(fmt.Sprintf("An error occurred while deleting image %s", image))
 			log.Println(err)
 		}
-		ui.Message("Image successfully deleted")
+		ui.Say("Image successfully deleted")
 	}
 
 	_, cancelled := state.GetOk(multistep.StateCancelled)
@@ -151,7 +151,7 @@ func (s *stepBuildVM) Cleanup(state multistep.StateBag) {
 		ui.Error("An error occurred while deleting the Virtual machine")
 		log.Println(err)
 	} else {
-		ui.Message("Virtual machine successfully deleted")
+		ui.Say("Virtual machine successfully deleted")
 	}
 
 }

--- a/builder/nutanix/step_clean_vm.go
+++ b/builder/nutanix/step_clean_vm.go
@@ -38,7 +38,7 @@ func (s *stepCleanVM) Run(ctx context.Context, state multistep.StateBag) multist
 	request.Metadata = vmResp.nutanix.Metadata
 
 	if s.Config.Clean.Cdrom {
-		ui.Message("Cleaning up CD-ROM in virtual machine...")
+		ui.Say("Cleaning up CD-ROM in virtual machine...")
 		d.CleanCD(ctx, request)
 	}
 
@@ -48,7 +48,7 @@ func (s *stepCleanVM) Run(ctx context.Context, state multistep.StateBag) multist
 		return multistep.ActionHalt
 	}
 
-	ui.Message("Virtual machine cleaned successfully.")
+	ui.Say("Virtual machine cleaned successfully.")
 	return multistep.ActionContinue
 }
 

--- a/builder/nutanix/step_create_image.go
+++ b/builder/nutanix/step_create_image.go
@@ -41,7 +41,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 				size: *vm.nutanix.Spec.Resources.DiskList[i].DiskSizeBytes,
 			})
 			diskID := fmt.Sprintf("%s:%d", *vm.nutanix.Spec.Resources.DiskList[i].DeviceProperties.DiskAddress.AdapterType, *vm.nutanix.Spec.Resources.DiskList[i].DeviceProperties.DiskAddress.DeviceIndex)
-			ui.Message("Found disk to copy: " + diskID)
+			ui.Say("Found disk to copy: " + diskID)
 		}
 	}
 
@@ -68,7 +68,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 			size: diskToCopy.size,
 		})
 
-		ui.Message(fmt.Sprintf("Image successfully created: %s (%s)", *imageResponse.image.Spec.Name, *imageResponse.image.Metadata.UUID))
+		ui.Say(fmt.Sprintf("Image successfully created: %s (%s)", *imageResponse.image.Spec.Name, *imageResponse.image.Metadata.UUID))
 	}
 
 	state.Put("image_uuid", imageList)
@@ -97,7 +97,7 @@ func (s *stepCreateImage) Cleanup(state multistep.StateBag) {
 				ui.Error("An error occurred while deleting image")
 				return
 			} else {
-				ui.Message(fmt.Sprintf("Image successfully deleted (%s)", image.uuid))
+				ui.Say(fmt.Sprintf("Image successfully deleted (%s)", image.uuid))
 			}
 		}
 	}

--- a/builder/nutanix/step_export_image.go
+++ b/builder/nutanix/step_export_image.go
@@ -83,14 +83,14 @@ func (s *stepExportImage) Run(ctx context.Context, state multistep.StateBag) mul
 			name = name + ".img"
 			os.Rename(tempDestinationPath, name)
 
-			ui.Message(fmt.Sprintf("image %s exported", name))
+			ui.Say(fmt.Sprintf("image %s exported", name))
 
 		case <-sigChan:
 			// We received a signal, cancel the copy operation
 			toRead.Close()
 			f.Close()
 			os.Remove(tempDestinationPath)
-			ui.Message("image export cancelled")
+			ui.Say("image export cancelled")
 			return multistep.ActionHalt
 		}
 

--- a/builder/nutanix/step_export_ova.go
+++ b/builder/nutanix/step_export_ova.go
@@ -64,13 +64,13 @@ func (s *StepExportOVA) Run(ctx context.Context, state multistep.StateBag) multi
 			return multistep.ActionHalt
 		}
 
-		ui.Message(fmt.Sprintf("Image exported as \"%s\"", name))
+		ui.Say(fmt.Sprintf("Image exported as \"%s\"", name))
 
 	case <-sigChan:
 		toRead.Close()
 		f.Close()
 		os.Remove(tempDestinationPath)
-		ui.Message("image export cancelled")
+		ui.Say("image export cancelled")
 		return multistep.ActionHalt
 	}
 


### PR DESCRIPTION
This pull request updates the Nutanix builder code by replacing all occurrences of the `ui.Message` method with `ui.Say` to support the next Packer SDK release.