### PR TITLE
improve windows 11 example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -17,3 +17,4 @@ Creating Ubuntu from ISO with Autoinstall:
 Windows Image (ISO Boot, VirtIO Drivers, cd_files)
 `packer build -only nutanix.windows .`
 
+Advanced Windows 11 EUC example is available in the [`windows`](https://github.com/nutanix-cloud-native/packer-plugin-nutanix/tree/main/example/windows) directory

--- a/example/windows/README.md
+++ b/example/windows/README.md
@@ -1,0 +1,47 @@
+# Windows 11 Template Creation on Nutanix using Packer
+
+This Packer template automates the creation of a Windows 11 VM template on a Nutanix cluster. The process configures the VM and performs several actions to ensure a complete and automated setup.
+
+## Actions Performed
+
+- **Create the VM**
+  - Allocate 1 vCPU, 4 cores, and 8192 MB of memory.
+  - Deploy the VM on the specified Nutanix cluster.
+
+- **Enable Security Features**
+  - Turn on Secure Boot.
+  - Add a virtual TPM (vTPM).
+  - Enable Credential Guard via `hardware_virtualization`.
+
+- **Attach Networking**
+  - Connect a NIC to the specified Nutanix subnet.
+
+- **Configure Boot Media**
+  - Attach a CD-ROM with a stock Windows 11 ISO.
+  - Attach a second CD-ROM with the Nutanix VirtIO ISO for drivers.
+
+- **Attach Storage**
+  - Add a 60 GB disk on the specified storage container.
+
+- **Set Boot Priority**
+  - Configure the VM to boot from CD-ROM.
+  - Wait 10 seconds after initial boot. (depending of your hardware this value need to be adjusted)
+  - Send keyboard input to bypass the "Press any key to boot from CD or DVD" prompt.
+
+- **Automate the Installation**
+  - Use `autounattend.xml` to:
+    - Install Windows automatically.
+    - Load VirtIO drivers from the attached ISO.
+    - Run `SetupComplete.cmd` to perform post-install tasks (e.g., enable WinRM).
+
+- **Connect for Provisioning**
+  - Use WinRM on port 5985.
+  - Set the connection timeout to 30 minutes.
+
+- **Clean Up**
+  - Detach all CD-ROMs after the build completes.
+
+- **Finalize the Build**
+  - Do **not** create a Nutanix image.
+  - Retain the VM for further testing or manual modifications.
+  - Create a Nutanix template from the built VM with the specified name and description.

--- a/example/windows/settings.auto.pkrvars.hcl
+++ b/example/windows/settings.auto.pkrvars.hcl
@@ -5,6 +5,7 @@ nutanix_endpoint    = "XXX"
 nutanix_port = 9440
 nutanix_cluster = "XXX"
 nutanix_subnet = "XXX"
+nutanix_storage_container_uuid = "XXX"
 windows_11_iso_image_name = "windows_11_business_editions_24h2_april_2025.iso"
 virtio_iso_image_name = "Nutanix-VirtIO-1.2.4.iso"
 winrm_username = "Administrator"

--- a/example/windows/source.nutanix.pkr.hcl
+++ b/example/windows/source.nutanix.pkr.hcl
@@ -1,21 +1,4 @@
-#//
-# This template will create a Windows 11 template on Nutanix using Packer. It configures and actions the following:
-# - Creates a VM with the specified resources (1 vCPU, 4 cores, 8192 MB memory) on the defined Nutanix cluster
-# - Enables secure boot and adds vTPM
-# - Enables Credential Guard (hardware_virtualization)
-# - Attaches a NIC to the specified Nutanix subnet
-# - Attaches a CD ROM and Boots from a stock Winows 11 ISO file
-# - Attaches a Nutanix VirtIO ISO for drivers
-# - Attaches a disk of 60GB size on a specified storage container
-# - Configures the boot priority to CD ROM
-# - Waits 10 seconds after the intial boot and then sends the boot commands to skip the Windows "Press any key to boot from CD or DVD" prompt
-# - Uses an autounattend.xml file to automate the Windows installation including adding the VirtIO drivers (from attached ISO) and using a SetupComplete.cmd script to run post-installation tasks such as enabling WinRM for Packer
-# - Connects to the VM using WinRM on port 5985 with a timeout of 30 minutes
-# - Removes all CD ROMs after the build is complete
-# - Skips creating a Nutanix image, as a template will be used
-# - Retains the VM after the build is complete for further testing or modifications
-# - Creates a Nutanix template from the VM with a specified name and description
-# //
+
 
 source "nutanix" "windows11" {
     nutanix_username    = var.nutanix_username
@@ -24,7 +7,6 @@ source "nutanix" "windows11" {
     nutanix_port        = var.nutanix_port
     nutanix_insecure    = var.nutanix_insecure
     cluster_name        = var.nutanix_cluster
-    # winrm_host          = "10.2.3.4"
     os_type             = "Windows"
     communicator        = "winrm"
     cpu                 = 1
@@ -51,6 +33,7 @@ source "nutanix" "windows11" {
     vm_disks {
         image_type              = "DISK"
         disk_size_gb            = 60
+        storage_container_uuid  = var.nutanix_storage_container_uuid
     }
     vm_nics {
         subnet_name       = var.nutanix_subnet
@@ -58,8 +41,7 @@ source "nutanix" "windows11" {
     cd_files = [ 
         "files/autounattend.xml",
         "files/scripts/EnableWinRMforPacker.ps1",
-        "files/scripts/SetupComplete.cmd",
-        "files/scripts/StaticIP.ps1"
+        "files/scripts/SetupComplete.cmd"
     ]
     image_skip          = true
     vm_retain = true

--- a/example/windows/variables.pkr.hcl
+++ b/example/windows/variables.pkr.hcl
@@ -44,3 +44,7 @@ variable "winrm_password" {
   type = string
 }
 
+variable "nutanix_storage_container_uuid" {
+  type = string
+  description = "UUID of the storage container where the VM disk will be created."
+}


### PR DESCRIPTION
This pull request improves the example for automating the creation of a Windows 11 VM template on Nutanix using Packer. It includes detailed instructions, configuration updates, and new variables to support the process. The most important changes involve documentation enhancements, configuration updates for storage and networking, and the addition of new variables.

### Documentation Enhancements:
* [`example/windows/README.md`](diffhunk://#diff-9571c8bc9cebed4e56b420bb5e715365f688b9949edc71475929718556df76e1R1-R47): Added a comprehensive guide detailing the steps for creating a Windows 11 VM template on Nutanix using Packer, including VM configuration, security features, networking, boot media setup, installation automation, and cleanup.
* [`example/README.md`](diffhunk://#diff-bc501e6e1e9420017b2d954e834fd8c3afb7daf9e2eb780c46c491099a7c2f0eR20): Added a reference to the advanced Windows 11 EUC example in the `windows` directory.

### Configuration Updates:
* [`example/windows/source.nutanix.pkr.hcl`](diffhunk://#diff-517e8755f858d64626914f643a7fc42d2df6d6c89c0d086230cb126599b470f5R36-R44): Updated the VM disk configuration to include the `storage_container_uuid` parameter and removed unnecessary scripts from the `cd_files` section.
* [`example/windows/source.nutanix.pkr.hcl`](diffhunk://#diff-517e8755f858d64626914f643a7fc42d2df6d6c89c0d086230cb126599b470f5L1-R1): Removed outdated comments describing the template creation process to streamline the file.

### New Variables:
* [`example/windows/settings.auto.pkrvars.hcl`](diffhunk://#diff-28eeab44756ead64d20cd5d587a01853d8123f9a12504656ff6fdd339fe82356R8): Added the `nutanix_storage_container_uuid` variable to specify the storage container for VM disk creation.
* [`example/windows/variables.pkr.hcl`](diffhunk://#diff-b4999c029b2e1365bc46eca0984464579ca912caec148f87450ccba00f801312R47-R50): Defined the `nutanix_storage_container_uuid` variable with a description and type.