### PR TITLE
add debug mode support

### DIFF
--- a/builder/nutanix/builder.go
+++ b/builder/nutanix/builder.go
@@ -123,7 +123,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		})
 	}
 
-	b.runner = &multistep.BasicRunner{Steps: steps}
+	b.runner = commonsteps.NewRunnerWithPauseFn(steps, b.config.PackerConfig, ui, state)
 	b.runner.Run(ctx, state)
 
 	if rawErr, ok := state.GetOk("error"); ok {


### PR DESCRIPTION
This pull request modifies the `Run` method in the Nutanix builder to use a new runner implementation that supports a pause function, improving the flexibility and functionality of the build process.

Key change:

* [`builder/nutanix/builder.go`]: Replaced `multistep.BasicRunner` with `commonsteps.NewRunnerWithPauseFn`, enabling the use of a pause function during the execution of build steps. This change also integrates `PackerConfig` and `Ui` into the runner for better state management.