### PR TITLE
add MacAddress support

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -204,6 +204,7 @@ In this section, you have to define network you will to connect with one of this
 
 - `subnet_name` (string) - Name of the cluster subnet to use.
 - `subnet_uuid` (string) - UUID of the cluster subnet to use.
+- `mac_address` (string) - The network card MAC address. If not specified, a random MAC address will be generated.
 
 Sample
 ```hcl

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -530,6 +530,7 @@ func (*FlatVmDisk) HCL2Spec() map[string]hcldec.Spec {
 type FlatVmNIC struct {
 	SubnetName *string `mapstructure:"subnet_name" json:"subnet_name" required:"false" cty:"subnet_name" hcl:"subnet_name"`
 	SubnetUUID *string `mapstructure:"subnet_uuid" json:"subnet_uuid" required:"false" cty:"subnet_uuid" hcl:"subnet_uuid"`
+	MacAddress *string `mapstructure:"mac_address" json:"mac_address" required:"false" cty:"mac_address" hcl:"mac_address"`
 }
 
 // FlatMapstructure returns a new FlatVmNIC.
@@ -546,6 +547,7 @@ func (*FlatVmNIC) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"subnet_name": &hcldec.AttrSpec{Name: "subnet_name", Type: cty.String, Required: false},
 		"subnet_uuid": &hcldec.AttrSpec{Name: "subnet_uuid", Type: cty.String, Required: false},
+		"mac_address": &hcldec.AttrSpec{Name: "mac_address", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -530,6 +530,11 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vm VmConfig, state mu
 			IsConnected:     &isConnected,
 			SubnetReference: BuildReference(*subnet.Metadata.UUID, "subnet"),
 		}
+
+		if nic.MacAddress != "" {
+			newNIC.MacAddress = StringPtr(nic.MacAddress)
+		}
+
 		NICList = append(NICList, &newNIC)
 	}
 

--- a/builder/nutanix/utils.go
+++ b/builder/nutanix/utils.go
@@ -2,6 +2,7 @@ package nutanix
 
 import (
 	"errors"
+	"net"
 	"os"
 	"strings"
 
@@ -62,4 +63,9 @@ func commHost(host string) func(multistep.StateBag) (string, error) {
 func fileExists(filename string) bool {
 	_, err := os.Stat(filename)
 	return !errors.Is(err, os.ErrNotExist)
+}
+
+func isValidMACAddress(mac string) bool {
+	_, err := net.ParseMAC(mac)
+	return err == nil
 }

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -213,6 +213,7 @@ In this section, you have to define network you will to connect with one of this
 
 - `subnet_name` (string) - Name of the cluster subnet to use.
 - `subnet_uuid` (string) - UUID of the cluster subnet to use.
+- `mac_address` (string) - The network card MAC address. If not specified, a random MAC address will be generated.
 
 Sample
 ```hcl


### PR DESCRIPTION
This pull request introduces support for specifying a MAC address for virtual machine network interfaces in the Nutanix builder. It includes updates to documentation, configuration validation, and the driver implementation to handle this new feature. Additionally, it introduces a utility function for validating MAC addresses.

Fix #189 

### Feature Addition: MAC Address Specification
* [`.web-docs/components/builder/nutanix/README.md`](diffhunk://#diff-785699748597f8f41fe692d5800dcfc25e10ad1de6880a8da23ee7c995ab0e34R207): Updated documentation to include the new `mac_address` field for specifying the network card MAC address. If not provided, a random MAC address will be generated.
* [`builder/nutanix/config.go`](diffhunk://#diff-7839be77f2e6b64d78a48652f9529bf577a2d063f98779f9fb35e7756189dcf3R107): Added the `MacAddress` field to the `VmNIC` struct and implemented validation to check if the provided MAC address is valid. [[1]](diffhunk://#diff-7839be77f2e6b64d78a48652f9529bf577a2d063f98779f9fb35e7756189dcf3R107) [[2]](diffhunk://#diff-7839be77f2e6b64d78a48652f9529bf577a2d063f98779f9fb35e7756189dcf3R265-R279)
* [`builder/nutanix/config.hcl2spec.go`](diffhunk://#diff-690c8c0c69296bc15b08f247e16acfb80a08f1f965f38550405a5cbd988cae5bR533): Updated HCL2 specifications to include the `mac_address` attribute. [[1]](diffhunk://#diff-690c8c0c69296bc15b08f247e16acfb80a08f1f965f38550405a5cbd988cae5bR533) [[2]](diffhunk://#diff-690c8c0c69296bc15b08f247e16acfb80a08f1f965f38550405a5cbd988cae5bR550)
* [`builder/nutanix/driver.go`](diffhunk://#diff-0ea76eb85ab04b981fac2eaabfd5c7cbddbd07208717161699742fdd04b9ca28R533-R537): Modified the Nutanix driver to set the `MacAddress` field in the NIC configuration when provided.

### Utility Function for MAC Address Validation
* [`builder/nutanix/utils.go`](diffhunk://#diff-d48d8ed88f0aeb48d274e9653f7a9e450561bfbe078b8cd862f6c9740fe221c2R5): Added the `isValidMACAddress` function to validate MAC addresses using the `net.ParseMAC` method. [[1]](diffhunk://#diff-d48d8ed88f0aeb48d274e9653f7a9e450561bfbe078b8cd862f6c9740fe221c2R5) [[2]](diffhunk://#diff-d48d8ed88f0aeb48d274e9653f7a9e450561bfbe078b8cd862f6c9740fe221c2R67-R71)

### Documentation Updates
* [`docs/builders/nutanix.mdx`](diffhunk://#diff-e3bf31fea91fb90e9499f61d7e60f31d685ff58b8e730ef12fdc6f62c275bbdaR216): Updated the Nutanix builder documentation to reflect the addition of the `mac_address` field.

These changes collectively enhance the Nutanix builder by providing greater control over network interface configurations and ensuring proper validation of input data.