### PR TITLE
add fail_if_image_exists option

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -58,6 +58,7 @@ These parameters allow to configure everything around image creation, from the t
 - `image_delete` (bool) - Delete image once build process is completed (default is false).
 - `image_skip` (bool) - Skip image creation (default is false).
 - `image_export` (bool) - Export raw image in the current folder (default is false).
+- `fail_if_image_exists` (bool) - Fail the build if an image with the same name already exists (default is false).
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	ImageSkip                      bool           `mapstructure:"image_skip" json:"image_skip" required:"false"`
 	ImageDelete                    bool           `mapstructure:"image_delete" json:"image_delete" required:"false"`
 	ImageExport                    bool           `mapstructure:"image_export" json:"image_export" required:"false"`
+	FailIfImageExists              bool           `mapstructure:"fail_if_image_exists" required:"false"`
 	VmForceDelete                  bool           `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false"`
 	VmRetain                       bool           `mapstructure:"vm_retain" json:"vm_retain" required:"false"`
 	DisableStopInstance            bool           `mapstructure:"disable_stop_instance" required:"false"`
@@ -230,6 +231,12 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		log.Println("Setting image_skip to 'false' and image_delete to 'true', because image_export is 'true'")
 		c.ImageSkip = false
 		c.ImageDelete = true
+	}
+
+	// fail_if_image_exists and force_deregister are mutually exclusive
+	if c.FailIfImageExists && c.ForceDeregister {
+		log.Println("fail_if_image_exists and force_deregister are mutually exclusive, please use only one of them")
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("fail_if_image_exists and force_deregister are mutually exclusive, please use only one of them"))
 	}
 
 	// Set OVA format if not provided

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -169,6 +169,7 @@ type FlatConfig struct {
 	ImageSkip                 *bool               `mapstructure:"image_skip" json:"image_skip" required:"false" cty:"image_skip" hcl:"image_skip"`
 	ImageDelete               *bool               `mapstructure:"image_delete" json:"image_delete" required:"false" cty:"image_delete" hcl:"image_delete"`
 	ImageExport               *bool               `mapstructure:"image_export" json:"image_export" required:"false" cty:"image_export" hcl:"image_export"`
+	FailIfImageExists         *bool               `mapstructure:"fail_if_image_exists" required:"false" cty:"fail_if_image_exists" hcl:"fail_if_image_exists"`
 	VmForceDelete             *bool               `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false" cty:"vm_force_delete" hcl:"vm_force_delete"`
 	VmRetain                  *bool               `mapstructure:"vm_retain" json:"vm_retain" required:"false" cty:"vm_retain" hcl:"vm_retain"`
 	DisableStopInstance       *bool               `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
@@ -289,6 +290,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_skip":                   &hcldec.AttrSpec{Name: "image_skip", Type: cty.Bool, Required: false},
 		"image_delete":                 &hcldec.AttrSpec{Name: "image_delete", Type: cty.Bool, Required: false},
 		"image_export":                 &hcldec.AttrSpec{Name: "image_export", Type: cty.Bool, Required: false},
+		"fail_if_image_exists":         &hcldec.AttrSpec{Name: "fail_if_image_exists", Type: cty.Bool, Required: false},
 		"vm_force_delete":              &hcldec.AttrSpec{Name: "vm_force_delete", Type: cty.Bool, Required: false},
 		"vm_retain":                    &hcldec.AttrSpec{Name: "vm_retain", Type: cty.Bool, Required: false},
 		"disable_stop_instance":        &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -67,6 +67,7 @@ These parameters allow to configure everything around image creation, from the t
 - `image_delete` (bool) - Delete image once build process is completed (default is false).
 - `image_skip` (bool) - Skip image creation (default is false).
 - `image_export` (bool) - Export raw image in the current folder (default is false).
+- `fail_if_image_exists` (bool) - Fail the build if an image with the same name already exists (default is false).
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).


### PR DESCRIPTION
This pull request introduces a new configuration parameter, `fail_if_image_exists`, to enhance the Nutanix image creation process. The parameter ensures that the build fails if an image with the same name already exists, preventing unintended overwrites. Additionally, mutual exclusivity checks between `fail_if_image_exists` and `force_deregister` have been implemented, along with updates to the documentation and related logic.

Fix #227 

### New Feature: `fail_if_image_exists` Parameter

* **Configuration Updates**:
  - Added the `fail_if_image_exists` parameter to the `Config` struct in `builder/nutanix/config.go`.
  - Updated the `FlatConfig` struct and its HCL2 specification to include `fail_if_image_exists` in `builder/nutanix/config.hcl2spec.go`. 

* **Validation Logic**:
  - Implemented a check in the `Prepare` method to ensure `fail_if_image_exists` and `force_deregister` are not used simultaneously, as they are mutually exclusive.

### Driver Enhancements

* **Image Existence Handling**:
  - Updated the `SaveVMDisk` method in `builder/nutanix/driver.go` to incorporate `fail_if_image_exists`. The build now fails with appropriate error messages if an image with the same name exists. 

### Documentation Updates

* **README and Docs**:
  - Added descriptions of the `fail_if_image_exists` parameter to `.web-docs/components/builder/nutanix/README.md` and `docs/builders/nutanix.mdx`.