### PR TITLE
allow to set multiples values for a single category key

### DIFF
--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -634,11 +634,12 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vm VmConfig, state mu
 	}
 
 	if len(vm.VMCategories) != 0 {
-		c := make(map[string]string)
+		cm := make(map[string][]string)
 		for _, category := range vm.VMCategories {
-			c[category.Key] = category.Value
+			cm[category.Key] = append(cm[category.Key], category.Value)
 		}
-		req.Metadata.Categories = c
+		req.Metadata.UseCategoriesMapping = BoolPtr(true)
+		req.Metadata.CategoriesMapping = cm
 	}
 
 	if vm.Project != "" {


### PR DESCRIPTION
This pull request modifies the handling of VM categories in the `CreateRequest` method of the Nutanix driver to support multiple values per category key.

### Changes to VM category handling:

* [`builder/nutanix/driver.go`](diffhunk://#diff-0ea76eb85ab04b981fac2eaabfd5c7cbddbd07208717161699742fdd04b9ca28L637-R642): Updated the `CreateRequest` method to use a map of string slices (`map[string][]string`) for `VMCategories`, allowing multiple values per category key. Added a new field `UseCategoriesMapping` and updated `CategoriesMapping` in the request metadata accordingly.