### PR TITLE
fix: add nil checks for image name

### DIFF
--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -245,7 +245,7 @@ func findImageByName(ctx context.Context, conn *v3.Client, name string) (*v3.Ima
 
 	found := make([]*v3.ImageIntentResponse, 0)
 	for _, v := range entities {
-		if strings.EqualFold(*v.Spec.Name, name) {
+		if v.Spec != nil && v.Spec.Name != nil && strings.EqualFold(*v.Spec.Name, name) {
 			found = append(found, v)
 		}
 	}


### PR DESCRIPTION
This pull request improves the robustness of the `findImageByName` function in the Nutanix builder driver by adding additional nil checks before accessing the image name. This change prevents potential nil pointer dereferences when iterating over image entities.

Fix #287 

- Reliability improvement:
  * Added checks to ensure `Spec` and `Spec.Name` are not nil before comparing image names in the `findImageByName` function in `builder/nutanix/driver.go`.