### PR TITLE
feat: add support for Prism Central Service Accounts

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -13,6 +13,8 @@ These parameters allow to define information about platform and temporary VM use
   - `cluster_name` or `cluster_uuid` (string) - Nutanix cluster name or uuid used to create and store image.
   - `os_type` (string) - OS Type ("Linux" or "Windows").
 
+Starting `v1.1.4` the Nutanix Packer Plugin supports Prism Central Service Accounts. To use a Service Account, you need to provide `X-ntnx-api-key` as the `nutanix_username` and the corresponding API Key as the `nutanix_password`.
+
 ### Optional
   - `nutanix_port` (number) - Port used for connection to Prism Central.
   - `nutanix_insecure` (bool) - Authorize connection to Prism Central without valid certificate.

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -22,6 +22,8 @@ These parameters allow to define information about platform and temporary VM use
   - `cluster_name` or `cluster_uuid` (string) - Nutanix cluster name or uuid used to create and store image.
   - `os_type` (string) - OS Type ("Linux" or "Windows").
 
+Starting `v1.1.4` the Nutanix Packer Plugin supports Prism Central Service Accounts. To use a Service Account, you need to provide `X-ntnx-api-key` as the `nutanix_username` and the corresponding API Key as the `nutanix_password`.
+
 ### Optional
   - `nutanix_port` (number) - Port used for connection to Prism Central.
   - `nutanix_insecure` (bool) - Authorize connection to Prism Central without valid certificate.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/packer-plugin-sdk v0.6.2
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
-	github.com/nutanix-cloud-native/prism-go-client v0.5.3
+	github.com/nutanix-cloud-native/prism-go-client v0.5.5
 	github.com/zclconf/go-cty v1.16.3
 	golang.org/x/net v0.43.0
 )

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
-github.com/nutanix-cloud-native/prism-go-client v0.5.3 h1:kcwbrWQOkQHiK20LcL2HyRYMlOWXLgqR93JD7D9ZgAs=
-github.com/nutanix-cloud-native/prism-go-client v0.5.3/go.mod h1:N/O9fz5fimjb30RxlPbKbGs/Z2lqMgDqrb6CrsZvQrA=
+github.com/nutanix-cloud-native/prism-go-client v0.5.5 h1:xonicVCBo/JASp0R2ivlksLDAnnxSAQqsISXBqoNeYs=
+github.com/nutanix-cloud-native/prism-go-client v0.5.5/go.mod h1:N/O9fz5fimjb30RxlPbKbGs/Z2lqMgDqrb6CrsZvQrA=
 github.com/nywilken/go-cty v1.13.3 h1:03U99oXf3j3g9xgqAE3YGpixCjM8Mg09KZ0Ji9LzX0o=
 github.com/nywilken/go-cty v1.13.3/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=


### PR DESCRIPTION
This pull request updates documentation and dependencies to support Prism Central Service Accounts in the Nutanix Packer Plugin starting from version `v1.1.4`. The most important changes are grouped below:

**Documentation Updates:**

* Added instructions in `.web-docs/components/builder/nutanix/README.md` and `docs/builders/nutanix.mdx` explaining how to use Prism Central Service Accounts with the Nutanix Packer Plugin, including the required use of `X-ntnx-api-key` as `nutanix_username` and the API Key as `nutanix_password`. [[1]](diffhunk://#diff-785699748597f8f41fe692d5800dcfc25e10ad1de6880a8da23ee7c995ab0e34R16-R17) [[2]](diffhunk://#diff-e3bf31fea91fb90e9499f61d7e60f31d685ff58b8e730ef12fdc6f62c275bbdaR25-R26)

**Dependency Update:**

* Updated the `github.com/nutanix-cloud-native/prism-go-client` dependency in `go.mod` from version `v0.5.3` to `v0.5.5` to ensure compatibility with new features and bug fixes.