### PR TITLE
Add SkipVMCreateTaskCheck configuration option to debug VM creation

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.3"
+      version = ">= 1.1.4"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.3"
+      version = ">= 1.1.4"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	VmForceDelete                  bool           `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false"`
 	VmRetain                       bool           `mapstructure:"vm_retain" json:"vm_retain" required:"false"`
 	DisableStopInstance            bool           `mapstructure:"disable_stop_instance" required:"false"`
+	SkipVMCreateTaskCheck          bool           `mapstructure:"skip_vm_create_task_check" required:"false"`
 
 	ctx interpolate.Context
 }

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -173,6 +173,7 @@ type FlatConfig struct {
 	VmForceDelete             *bool               `mapstructure:"vm_force_delete" json:"vm_force_delete" required:"false" cty:"vm_force_delete" hcl:"vm_force_delete"`
 	VmRetain                  *bool               `mapstructure:"vm_retain" json:"vm_retain" required:"false" cty:"vm_retain" hcl:"vm_retain"`
 	DisableStopInstance       *bool               `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
+	SkipVMCreateTaskCheck     *bool               `mapstructure:"skip_vm_create_task_check" required:"false" cty:"skip_vm_create_task_check" hcl:"skip_vm_create_task_check"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -294,6 +295,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_force_delete":              &hcldec.AttrSpec{Name: "vm_force_delete", Type: cty.Bool, Required: false},
 		"vm_retain":                    &hcldec.AttrSpec{Name: "vm_retain", Type: cty.Bool, Required: false},
 		"disable_stop_instance":        &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
+		"skip_vm_create_task_check":    &hcldec.AttrSpec{Name: "skip_vm_create_task_check", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.3"
+      version = ">= 1.1.4"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/example/init/plugin.pkr.hcl
+++ b/example/init/plugin.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.3"
+      version = ">= 1.1.4"
       source = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.1.3"
+	Version = "1.1.4"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
This pull request introduces a new temporary feature to the Nutanix Packer builder that allows skipping the VM create task check, primarily for debugging purposes. It also bumps the plugin version to 1.1.4 across documentation, configuration, and version files.

Feature addition:

* Added a new configuration option `skip_vm_create_task_check` to the Nutanix builder, allowing users to skip the standard task check during VM creation for debugging. This includes updates to `Config`, `FlatConfig`, and HCL2 spec handling. [[1]](diffhunk://#diff-7839be77f2e6b64d78a48652f9529bf577a2d063f98779f9fb35e7756189dcf3R66) [[2]](diffhunk://#diff-690c8c0c69296bc15b08f247e16acfb80a08f1f965f38550405a5cbd988cae5bR176) [[3]](diffhunk://#diff-690c8c0c69296bc15b08f247e16acfb80a08f1f965f38550405a5cbd988cae5bR298)
* Implemented the `checkVm` function and integrated logic into the VM creation flow to use this new skip check option. [[1]](diffhunk://#diff-0ea76eb85ab04b981fac2eaabfd5c7cbddbd07208717161699742fdd04b9ca28R287-R312) [[2]](diffhunk://#diff-0ea76eb85ab04b981fac2eaabfd5c7cbddbd07208717161699742fdd04b9ca28R714-R719)

Version and documentation updates:

* Updated the plugin version to `1.1.4` in all relevant documentation, example config, and code files. [[1]](diffhunk://#diff-d240320fc87f7ae14f8d7a62c2cd1db6f4676aa33fa78d3c48a1d3d9c4c550c8L12-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35) [[3]](diffhunk://#diff-d240320fc87f7ae14f8d7a62c2cd1db6f4676aa33fa78d3c48a1d3d9c4c550c8L12-R12) [[4]](diffhunk://#diff-4b426eaaccdd978290702f4b4bdc2d14e7159fdff8592ab1f47c9f9fe949db68L4-R4) [[5]](diffhunk://#diff-f6bf0ae0d21c9408c6624174da11dafb369ce306f2cdcea704285d8acc87e19eL9-R9)