### PR TITLE
ci(e2e): run Packer E2E on NCN ARC runners with check_approvals and PC secrets

### DIFF
--- a/.github/workflows/test-plugin-e2e.yaml
+++ b/.github/workflows/test-plugin-e2e.yaml
@@ -10,9 +10,9 @@ on:
   workflow_dispatch:
     inputs:
       logs:
-        description: "Packer PACKER_LOG — default on; set 0 to disable verbose logs"
+        description: "Set 1 to activate full logs"
         required: false
-        default: "1"
+        default: "0"
 
 jobs:
   check_approvals:
@@ -87,8 +87,6 @@ jobs:
       PKR_VAR_nutanix_subnet: ${{ secrets.PKR_VAR_NUTANIX_SUBNET }}
       PKR_VAR_nutanix_port: "9440"
       PKR_VAR_nutanix_insecure: "true"
-      # Verbose Packer logs by default; workflow_dispatch input logs=0 turns off.
-      PACKER_LOG: ${{ github.event.inputs.logs == '0' && '0' || '1' }}
 
     steps:
       - name: Checkout Repository
@@ -116,45 +114,6 @@ jobs:
         run: |
           packer plugins install --path /tmp/packer-plugin-nutanix "github.com/nutanix-cloud-native/nutanix"
 
-      - name: Prism Central connectivity (debug)
-        shell: bash
-        run: |
-          set -euo pipefail
-          EP="${PKR_VAR_nutanix_endpoint}"
-          PORT="${PKR_VAR_nutanix_port:-9440}"
-          BASE="https://${EP}:${PORT}"
-          echo "=== Prism Central connectivity (from runner to PC) ==="
-          echo "Host: ${EP}  Port: ${PORT}"
-          echo "--- Unauthenticated probe (TLS + routing; status often 401/302) ---"
-          set +e
-          OUT1=$(curl -skS --connect-timeout 25 -o /dev/null -w "%{http_code}" "${BASE}/" 2>/tmp/pc-curl-root.txt)
-          RC1=$?
-          set -e
-          if [[ "${RC1}" -ne 0 ]]; then
-            echo "::error::Cannot reach ${BASE}/ (curl exit ${RC1}). DNS, firewall, VPN, or wrong host."
-            cat /tmp/pc-curl-root.txt || true
-            exit 1
-          fi
-          echo "GET ${BASE}/ -> HTTP ${OUT1}"
-          echo "--- Authenticated v3 /users/me (expect HTTP 200 if credentials OK) ---"
-          HTTP=$(curl -skS --connect-timeout 25 -u "${PKR_VAR_nutanix_username}:${PKR_VAR_nutanix_password}" \
-            -o /tmp/pc-users-me.json -w "%{http_code}" \
-            "${BASE}/api/nutanix/v3/users/me" 2>/tmp/pc-curl-err.txt) || true
-          if [[ -s /tmp/pc-curl-err.txt ]]; then
-            echo "curl stderr:" && cat /tmp/pc-curl-err.txt
-          fi
-          echo "HTTP status: ${HTTP}"
-          if [[ -s /tmp/pc-users-me.json ]]; then
-            echo "Response (first 400 chars):"
-            head -c 400 /tmp/pc-users-me.json || true
-            echo
-          fi
-          if [[ "${HTTP}" != "200" ]]; then
-            echo "::error::Prism API /users/me returned HTTP ${HTTP} (not 200). Check PC URL, user/password, TLS, and that this account can use the API."
-            exit 1
-          fi
-          echo "=== Prism Central connectivity OK ==="
-
       - name: Run `packer init`
         id: init
         run: |
@@ -163,10 +122,14 @@ jobs:
       - name: Run `packer validate`
         id: validate
         run: packer validate -var "test=${{ matrix.test}}" .
+        env:
+          PACKER_LOG: ${{ github.event.inputs.logs }}
 
       - name: Run `packer build`
         id: build
         run: packer build -var "test=${{ matrix.test}}" .
+        env:
+          PACKER_LOG: ${{ github.event.inputs.logs }}
 
   results:
     if: ${{ always() }}

--- a/.github/workflows/test-plugin-e2e.yaml
+++ b/.github/workflows/test-plugin-e2e.yaml
@@ -38,7 +38,7 @@ jobs:
   plugin-build:
     needs: check_approvals
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.check_approvals.outputs.external_pr == 'false') || (github.event_name == 'pull_request_target' && needs.check_approvals.outputs.external_pr == 'true' && needs.check_approvals.outputs.check_approvals == 'true') }}
-    runs-on: self-hosted-ncn-docker-small
+    runs-on: self-hosted-ncn-docker-medium
     outputs:
       test-list: ${{ steps.test-list.outputs.list}}
 
@@ -74,7 +74,7 @@ jobs:
       matrix:
         test: ${{fromJSON(needs.plugin-build.outputs.test-list)}}
 
-    runs-on: self-hosted-ncn-docker-small
+    runs-on: self-hosted-ncn-docker-medium
     defaults:
       run:
         working-directory: test/e2e/${{ matrix.test}}

--- a/.github/workflows/test-plugin-e2e.yaml
+++ b/.github/workflows/test-plugin-e2e.yaml
@@ -5,13 +5,13 @@ on:
   workflow_dispatch:
     inputs:
       logs:
-        description: "Set 1 to activate full logs"
+        description: "Packer PACKER_LOG — default on; set 0 to disable verbose logs"
         required: false
-        default: "0"
+        default: "1"
 
 jobs:
   plugin-build:
-    runs-on: [self-hosted, nxlab, packer]
+    runs-on: self-hosted-ncn-docker-medium
     outputs:
       test-list: ${{ steps.test-list.outputs.list}}
 
@@ -47,10 +47,21 @@ jobs:
       matrix:
         test: ${{fromJSON(needs.plugin-build.outputs.test-list)}}
 
-    runs-on: [self-hosted, nxlab, packer]
+    runs-on: self-hosted-ncn-docker-medium
     defaults:
       run:
         working-directory: test/e2e/${{ matrix.test}}
+
+    env:
+      PKR_VAR_nutanix_endpoint: ${{ secrets.PKR_VAR_NUTANIX_ENDPOINT }}
+      PKR_VAR_nutanix_username: ${{ secrets.PKR_VAR_NUTANIX_USERNAME }}
+      PKR_VAR_nutanix_password: ${{ secrets.PKR_VAR_NUTANIX_PASSWORD }}
+      PKR_VAR_nutanix_cluster: ${{ secrets.PKR_VAR_NUTANIX_CLUSTER }}
+      PKR_VAR_nutanix_subnet: ${{ secrets.PKR_VAR_NUTANIX_SUBNET }}
+      PKR_VAR_nutanix_port: "9440"
+      PKR_VAR_nutanix_insecure: "true"
+      # Verbose Packer logs by default; workflow_dispatch input logs=0 turns off.
+      PACKER_LOG: ${{ github.event.inputs.logs == '0' && '0' || '1' }}
 
     steps:
       - name: Checkout Repository
@@ -78,6 +89,45 @@ jobs:
         run: |
           packer plugins install --path /tmp/packer-plugin-nutanix "github.com/nutanix-cloud-native/nutanix"
 
+      - name: Prism Central connectivity (debug)
+        shell: bash
+        run: |
+          set -euo pipefail
+          EP="${PKR_VAR_nutanix_endpoint}"
+          PORT="${PKR_VAR_nutanix_port:-9440}"
+          BASE="https://${EP}:${PORT}"
+          echo "=== Prism Central connectivity (from runner to PC) ==="
+          echo "Host: ${EP}  Port: ${PORT}"
+          echo "--- Unauthenticated probe (TLS + routing; status often 401/302) ---"
+          set +e
+          OUT1=$(curl -skS --connect-timeout 25 -o /dev/null -w "%{http_code}" "${BASE}/" 2>/tmp/pc-curl-root.txt)
+          RC1=$?
+          set -e
+          if [[ "${RC1}" -ne 0 ]]; then
+            echo "::error::Cannot reach ${BASE}/ (curl exit ${RC1}). DNS, firewall, VPN, or wrong host."
+            cat /tmp/pc-curl-root.txt || true
+            exit 1
+          fi
+          echo "GET ${BASE}/ -> HTTP ${OUT1}"
+          echo "--- Authenticated v3 /users/me (expect HTTP 200 if credentials OK) ---"
+          HTTP=$(curl -skS --connect-timeout 25 -u "${PKR_VAR_nutanix_username}:${PKR_VAR_nutanix_password}" \
+            -o /tmp/pc-users-me.json -w "%{http_code}" \
+            "${BASE}/api/nutanix/v3/users/me" 2>/tmp/pc-curl-err.txt) || true
+          if [[ -s /tmp/pc-curl-err.txt ]]; then
+            echo "curl stderr:" && cat /tmp/pc-curl-err.txt
+          fi
+          echo "HTTP status: ${HTTP}"
+          if [[ -s /tmp/pc-users-me.json ]]; then
+            echo "Response (first 400 chars):"
+            head -c 400 /tmp/pc-users-me.json || true
+            echo
+          fi
+          if [[ "${HTTP}" != "200" ]]; then
+            echo "::error::Prism API /users/me returned HTTP ${HTTP} (not 200). Check PC URL, user/password, TLS, and that this account can use the API."
+            exit 1
+          fi
+          echo "=== Prism Central connectivity OK ==="
+
       - name: Run `packer init`
         id: init
         run: |
@@ -86,18 +136,14 @@ jobs:
       - name: Run `packer validate`
         id: validate
         run: packer validate -var "test=${{ matrix.test}}" .
-        env:
-          PACKER_LOG: ${{ github.event.inputs.logs }}
 
       - name: Run `packer build`
         id: build
         run: packer build -var "test=${{ matrix.test}}" .
-        env:
-          PACKER_LOG: ${{ github.event.inputs.logs }}
 
   results:
     if: ${{ always() }}
-    runs-on: [self-hosted, nxlab, packer]
+    runs-on: ubuntu-latest
     name: Final E2E results
     needs: [e2e]
     steps:

--- a/.github/workflows/test-plugin-e2e.yaml
+++ b/.github/workflows/test-plugin-e2e.yaml
@@ -38,7 +38,7 @@ jobs:
   plugin-build:
     needs: check_approvals
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.check_approvals.outputs.external_pr == 'false') || (github.event_name == 'pull_request_target' && needs.check_approvals.outputs.external_pr == 'true' && needs.check_approvals.outputs.check_approvals == 'true') }}
-    runs-on: self-hosted-ncn-docker-medium
+    runs-on: self-hosted-ncn-docker-small
     outputs:
       test-list: ${{ steps.test-list.outputs.list}}
 
@@ -74,17 +74,17 @@ jobs:
       matrix:
         test: ${{fromJSON(needs.plugin-build.outputs.test-list)}}
 
-    runs-on: self-hosted-ncn-docker-medium
+    runs-on: self-hosted-ncn-docker-small
     defaults:
       run:
         working-directory: test/e2e/${{ matrix.test}}
 
     env:
-      PKR_VAR_nutanix_endpoint: ${{ secrets.PKR_VAR_NUTANIX_ENDPOINT }}
-      PKR_VAR_nutanix_username: ${{ secrets.PKR_VAR_NUTANIX_USERNAME }}
-      PKR_VAR_nutanix_password: ${{ secrets.PKR_VAR_NUTANIX_PASSWORD }}
-      PKR_VAR_nutanix_cluster: ${{ secrets.PKR_VAR_NUTANIX_CLUSTER }}
-      PKR_VAR_nutanix_subnet: ${{ secrets.PKR_VAR_NUTANIX_SUBNET }}
+      PKR_VAR_nutanix_endpoint: ${{ vars.PRISM_CENTRAL_CI }}
+      PKR_VAR_nutanix_username: ${{ vars.PRISM_CENTRAL_CI_USERNAME }}
+      PKR_VAR_nutanix_password: ${{ secrets.PRISM_CENTRAL_CI_PASSWORD }}
+      PKR_VAR_nutanix_cluster: ${{ vars.PRISM_ELEMENT_CI_WORKLOADS }}
+      PKR_VAR_nutanix_subnet: ${{ vars.PRISM_ELEMENT_CI_WORKLOADS_SUBNET }}
       PKR_VAR_nutanix_port: "9440"
       PKR_VAR_nutanix_insecure: "true"
 


### PR DESCRIPTION
Moves the E2E workflow off the legacy [self-hosted, nxlab, packer] labels onto self-hosted-ncn-docker-medium, wires Nutanix settings from repository secrets (PKR_VAR_*)