### PR TITLE
ci: pin Go version from go.mod in notify integration workflows

### DIFF
--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -22,6 +22,8 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
       # Ensure that Docs are Compiled
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
       - shell: bash
         run: make generate
       - shell: bash

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -26,6 +26,8 @@ jobs:
           ref: ${{ github.ref }}
       # Ensure that Docs are Compiled
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
       - shell: bash
         run: make generate
       - shell: bash


### PR DESCRIPTION
## Summary

Adds `go-version-file: go.mod` to `actions/setup-go` in the **Notify Integration Release** workflows (tag and manual), so CI installs the same Go version as `go.mod` (`go 1.25.0`).

## Problem

Those two workflows previously called `setup-go` without a version. The default toolchain on the runner could be older than the `go` directive in `go.mod`. In that case `go list -m github.com/hashicorp/packer-plugin-sdk` fails during `make generate`, the Makefile’s SDK version resolves empty, and `go install .../packer-sdc@...` fails.

## Changes

- `.github/workflows/notify-integration-release-via-tag.yaml` — `with: go-version-file: go.mod`
- `.github/workflows/notify-integration-release-via-manual.yaml` — same

This matches other workflows (`integration`, `release`, `ensure-docs-compiled`, etc.).

## Testing

- [x] Push branch and confirm the relevant workflow(s) pass (or run workflow_dispatch for the manual notify job if applicable).