### PR TITLE
use filepath.Split when uploading generated ISO image files

### DIFF
--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -1042,7 +1043,7 @@ func (d *NutanixDriver) CreateImageFile(ctx context.Context, filePath string, vm
 		return nil, fmt.Errorf("error creating V4 client: %s", err.Error())
 	}
 
-	_, file := path.Split(filePath)
+	_, file := filepath.Split(filePath)
 
 	log.Printf("creating and uploading image: %s", file)
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/packer-plugin-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Uses filepath.Split to obtain the filename of the ISO generated from the "cd_files" parameter.  Currently, path.Split is used, which only splits on "/".  filepath.Split will use the appropriate delimiter for the underlying OS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #354

**How Has This Been Tested?**:

Running builder on a Windows based system with the "cd_files" property set.


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
NONE
