### PR TITLE
chore: update Nutanix plugin version from 1.1.6 to 1.1.7 in configuration and documentation

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.6"
+      version = ">= 1.1.7"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.6"
+      version = ">= 1.1.7"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.6"
+      version = ">= 1.1.7"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/example/plugin.pkr.hcl
+++ b/example/plugin.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.6"
+      version = ">= 1.1.7"
       source = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.1.6"
+	Version = "1.1.7"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
This pull request updates the Nutanix Packer plugin to version 1.1.7 throughout the documentation, example configuration, and source code. This ensures consistency across all references and that users will install the latest version.

Version bump to 1.1.7:

* Updated the required plugin version for `nutanix` from `>= 1.1.6` to `>= 1.1.7` in `.web-docs/README.md`, `docs/README.md`, `README.md`, and `example/plugin.pkr.hcl` to instruct users to use the latest version. [[1]](diffhunk://#diff-d240320fc87f7ae14f8d7a62c2cd1db6f4676aa33fa78d3c48a1d3d9c4c550c8L12-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35) [[3]](diffhunk://#diff-76b6307bdd2d08982de7b5cc50f57161e4782a183d7886ec64f5b3f869e86b29L4-R4)
* Updated the `Version` variable in `version/version.go` from `"1.1.6"` to `"1.1.7"` to reflect the new release.