### PR TITLE
fix: update data type for winrm_use_ntlm parameter in documentation

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -667,7 +667,7 @@ You can tune this delay on a per-builder basis by specifying
 
 - `winrm_insecure` (bool) - If `true`, do not check server certificate chain and host name.
 
-- `winrm_use_ntlm` (bool) - If `true`, NTLMv2 authentication (with session security) will be used
+- `winrm_use_ntlm` (boolean) - If `true`, NTLMv2 authentication (with session security) will be used
   for WinRM, rather than default (basic authentication), removing the
   requirement for basic authentication to be enabled within the target
   guest. Further reading for remote connection authentication can be found


### PR DESCRIPTION
This pull request makes a minor documentation update to the Nutanix builder README. The change clarifies the data type for the `winrm_use_ntlm` configuration option.

- Documentation update:
  * Changed the type description of `winrm_use_ntlm` from `bool` to `boolean` in `.web-docs/components/builder/nutanix/README.md` for consistency and clarity.