### PR TITLE
fix: handle duplicate image names gracefully instead of hard failure

### DIFF
--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -62,6 +62,7 @@ These parameters allow to configure everything around image creation, from the t
 - `image_skip` (bool) - Skip image creation (default is false).
 - `image_export` (bool) - Export raw image in the current folder (default is false).
 - `fail_if_image_exists` (bool) - Fail the build if an image with the same name already exists (default is false).
+- `allow_duplicate_images` (bool) - When `true`, the plugin tolerates multiple images with the same name in the Prism Central image library. Instead of failing, it selects the newest ready image. This is useful in parallel CI environments where concurrent builds may create images with identical names. When `false` (the default), the plugin returns an error if more than one image matches by name, which is the recommended behavior for production systems.
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	ForceDeregister                bool           `mapstructure:"force_deregister" json:"force_deregister" required:"false"`
 	ImageDescription               string         `mapstructure:"image_description" json:"image_description" required:"false"`
 	ImageCategories                []Category     `mapstructure:"image_categories" required:"false"`
+	AllowDuplicateImages           bool           `mapstructure:"allow_duplicate_images" json:"allow_duplicate_images" required:"false"`
 	ImageSkip                      bool           `mapstructure:"image_skip" json:"image_skip" required:"false"`
 	ImageDelete                    bool           `mapstructure:"image_delete" json:"image_delete" required:"false"`
 	ImageExport                    bool           `mapstructure:"image_export" json:"image_export" required:"false"`

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -169,6 +169,7 @@ type FlatConfig struct {
 	ForceDeregister           *bool               `mapstructure:"force_deregister" json:"force_deregister" required:"false" cty:"force_deregister" hcl:"force_deregister"`
 	ImageDescription          *string             `mapstructure:"image_description" json:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageCategories           []FlatCategory      `mapstructure:"image_categories" required:"false" cty:"image_categories" hcl:"image_categories"`
+	AllowDuplicateImages      *bool               `mapstructure:"allow_duplicate_images" json:"allow_duplicate_images" required:"false" cty:"allow_duplicate_images" hcl:"allow_duplicate_images"`
 	ImageSkip                 *bool               `mapstructure:"image_skip" json:"image_skip" required:"false" cty:"image_skip" hcl:"image_skip"`
 	ImageDelete               *bool               `mapstructure:"image_delete" json:"image_delete" required:"false" cty:"image_delete" hcl:"image_delete"`
 	ImageExport               *bool               `mapstructure:"image_export" json:"image_export" required:"false" cty:"image_export" hcl:"image_export"`
@@ -292,6 +293,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"force_deregister":             &hcldec.AttrSpec{Name: "force_deregister", Type: cty.Bool, Required: false},
 		"image_description":            &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_categories":             &hcldec.BlockListSpec{TypeName: "image_categories", Nested: hcldec.ObjectSpec((*FlatCategory)(nil).HCL2Spec())},
+		"allow_duplicate_images":       &hcldec.AttrSpec{Name: "allow_duplicate_images", Type: cty.Bool, Required: false},
 		"image_skip":                   &hcldec.AttrSpec{Name: "image_skip", Type: cty.Bool, Required: false},
 		"image_delete":                 &hcldec.AttrSpec{Name: "image_delete", Type: cty.Bool, Required: false},
 		"image_export":                 &hcldec.AttrSpec{Name: "image_export", Type: cty.Bool, Required: false},

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -337,12 +337,14 @@ func sourceImageExists(ctx context.Context, v4Client *convergedv4.Client, name, 
 		}
 	}
 
-	// Prefer exact URL match
+	// Prefer exact URL match, selecting newest if multiple exist
 	if len(urlMatched) == 1 {
 		return urlMatched[0], nil
 	}
 	if len(urlMatched) > 1 {
-		return nil, fmt.Errorf("your query returned more than one result with same Name/URI")
+		log.Printf("WARNING: found %d images with same Name/URI '%s', selecting newest", len(urlMatched), name)
+		sortImagesByCreateTimeDesc(urlMatched)
+		return urlMatched[0], nil
 	}
 
 	// Fall back to name-only match (V4 API may not return Source for downloaded images)
@@ -351,7 +353,9 @@ func sourceImageExists(ctx context.Context, v4Client *convergedv4.Client, name, 
 		return nameMatched[0], nil
 	}
 	if len(nameMatched) > 1 {
-		return nil, fmt.Errorf("your query returned more than one result with name '%s'", name)
+		log.Printf("WARNING: found %d images with name '%s', selecting newest", len(nameMatched), name)
+		sortImagesByCreateTimeDesc(nameMatched)
+		return nameMatched[0], nil
 	}
 
 	return nil, nil

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -278,7 +278,7 @@ func findProjectByName(ctx context.Context, conn *v3.Client, name string) (*v3.P
 // sourceImageExists checks if an image with the given name exists using V4 API.
 // It verifies images are ready (SizeBytes > 0) and optionally validates the checksum
 // to detect corrupt/partial images. Matching priority: name+URL > name+checksum > name-only.
-func sourceImageExists(ctx context.Context, v4Client *convergedv4.Client, name, uri, expectedChecksum string) (*imageModels.Image, error) {
+func sourceImageExists(ctx context.Context, v4Client *convergedv4.Client, name, uri, expectedChecksum string, allowDuplicates bool) (*imageModels.Image, error) {
 	images, err := v4Client.Images.List(ctx, converged.WithFilter(fmt.Sprintf("name eq '%s'", name)))
 	if err != nil {
 		return nil, err
@@ -337,11 +337,14 @@ func sourceImageExists(ctx context.Context, v4Client *convergedv4.Client, name, 
 		}
 	}
 
-	// Prefer exact URL match, selecting newest if multiple exist
+	// Prefer exact URL match
 	if len(urlMatched) == 1 {
 		return urlMatched[0], nil
 	}
 	if len(urlMatched) > 1 {
+		if !allowDuplicates {
+			return nil, fmt.Errorf("your query returned more than one result with same Name/URI. Use allow_duplicate_images to only select the newest image")
+		}
 		log.Printf("WARNING: found %d images with same Name/URI '%s', selecting newest", len(urlMatched), name)
 		sortImagesByCreateTimeDesc(urlMatched)
 		return urlMatched[0], nil
@@ -353,6 +356,9 @@ func sourceImageExists(ctx context.Context, v4Client *convergedv4.Client, name, 
 		return nameMatched[0], nil
 	}
 	if len(nameMatched) > 1 {
+		if !allowDuplicates {
+			return nil, fmt.Errorf("your query returned more than one result with name '%s'. Use allow_duplicate_images to only select the newest image", name)
+		}
 		log.Printf("WARNING: found %d images with name '%s', selecting newest", len(nameMatched), name)
 		sortImagesByCreateTimeDesc(nameMatched)
 		return nameMatched[0], nil
@@ -371,8 +377,8 @@ func findImageByUUID(ctx context.Context, v4Client *convergedv4.Client, uuid str
 }
 
 // findImageByName finds an image by name using V4 API
-func findImageByName(ctx context.Context, v4Client *convergedv4.Client, name string) (*nutanixImage, error) {
-	img, err := findImageByNameHelper(ctx, v4Client, name)
+func findImageByName(ctx context.Context, v4Client *convergedv4.Client, name string, allowDuplicates bool) (*nutanixImage, error) {
+	img, err := findImageByNameHelper(ctx, v4Client, name, allowDuplicates)
 	if err != nil {
 		return nil, err
 	}
@@ -536,7 +542,7 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vmConfig VmConfig, st
 					imageToDelete = append(imageToDelete, image.UUID())
 				}
 			} else if disk.SourceImageName != "" {
-				image, err = findImageByName(ctx, v4Client, disk.SourceImageName)
+				image, err = findImageByName(ctx, v4Client, disk.SourceImageName, d.Config.AllowDuplicateImages)
 				if err != nil {
 					return nil, fmt.Errorf("error while findImageByName, %s", err.Error())
 				}
@@ -631,7 +637,7 @@ func (d *NutanixDriver) CreateRequest(ctx context.Context, vmConfig VmConfig, st
 					imageToDelete = append(imageToDelete, image.UUID())
 				}
 			} else if disk.SourceImageName != "" {
-				image, err = findImageByName(ctx, v4Client, disk.SourceImageName)
+				image, err = findImageByName(ctx, v4Client, disk.SourceImageName, d.Config.AllowDuplicateImages)
 				if err != nil {
 					return nil, fmt.Errorf("error while findImageByName, %s", err.Error())
 				}
@@ -968,7 +974,7 @@ func (d *NutanixDriver) CreateImageURL(ctx context.Context, disk VmDisk, vm VmCo
 		return nil, fmt.Errorf("error while getting cluster: %s", err.Error())
 	}
 
-	existingImage, err := sourceImageExists(ctx, v4Client, file, disk.SourceImageURI, disk.SourceImageChecksum)
+	existingImage, err := sourceImageExists(ctx, v4Client, file, disk.SourceImageURI, disk.SourceImageChecksum, d.Config.AllowDuplicateImages)
 	if err != nil {
 		return nil, fmt.Errorf("error while checking if image exists, %s", err.Error())
 	}
@@ -1081,7 +1087,7 @@ func (d *NutanixDriver) CreateImageFile(ctx context.Context, filePath string, vm
 		return nil, fmt.Errorf("error while uploading image: %s", err.Error())
 	}
 
-	createdImage, err := findImageByName(ctx, v4Client, file)
+	createdImage, err := findImageByName(ctx, v4Client, file, d.Config.AllowDuplicateImages)
 	if err != nil {
 		return nil, fmt.Errorf("error while getting created image: %s", err.Error())
 	}
@@ -1110,7 +1116,7 @@ func (d *NutanixDriver) GetImage(ctx context.Context, imagename string) (*nutani
 		return nil, fmt.Errorf("error creating V4 client: %s", err.Error())
 	}
 
-	image, err := findImageByName(ctx, v4Client, imagename)
+	image, err := findImageByName(ctx, v4Client, imagename, d.Config.AllowDuplicateImages)
 	if err != nil {
 		return nil, fmt.Errorf("error while GetImage, %s", err.Error())
 	}

--- a/builder/nutanix/helpers.go
+++ b/builder/nutanix/helpers.go
@@ -64,9 +64,9 @@ func findImageByUUIDHelper(ctx context.Context, client *convergedv4.Client, uuid
 }
 
 // findImageByNameHelper finds an image by name using V4 API.
-// When multiple images share the same name (common in parallel CI), the newest
-// ready image is selected instead of returning an error.
-func findImageByNameHelper(ctx context.Context, client *convergedv4.Client, name string) (*imageModels.Image, error) {
+// When allowDuplicates is true and multiple images share the same name,
+// the newest ready image is selected instead of returning an error.
+func findImageByNameHelper(ctx context.Context, client *convergedv4.Client, name string, allowDuplicates bool) (*imageModels.Image, error) {
 	images, err := client.Images.List(ctx, converged.WithFilter(fmt.Sprintf("name eq '%s'", name)))
 	if err != nil {
 		return nil, err
@@ -84,6 +84,9 @@ func findImageByNameHelper(ctx context.Context, client *convergedv4.Client, name
 	}
 
 	if len(found) > 1 {
+		if !allowDuplicates {
+			return nil, fmt.Errorf("found more than one image with name %s. Use allow_duplicate_images to only select the newest image", name)
+		}
 		log.Printf("WARNING: found %d images with name '%s', selecting the newest ready image", len(found), name)
 		found = selectNewestReadyImage(found)
 		if len(found) == 0 {

--- a/builder/nutanix/helpers.go
+++ b/builder/nutanix/helpers.go
@@ -3,6 +3,8 @@ package nutanix
 import (
 	"context"
 	"fmt"
+	"log"
+	"sort"
 	"strings"
 
 	"github.com/nutanix-cloud-native/prism-go-client/converged"
@@ -61,7 +63,9 @@ func findImageByUUIDHelper(ctx context.Context, client *convergedv4.Client, uuid
 	return img, nil
 }
 
-// findImageByNameHelper finds an image by name using V4 API
+// findImageByNameHelper finds an image by name using V4 API.
+// When multiple images share the same name (common in parallel CI), the newest
+// ready image is selected instead of returning an error.
 func findImageByNameHelper(ctx context.Context, client *convergedv4.Client, name string) (*imageModels.Image, error) {
 	images, err := client.Images.List(ctx, converged.WithFilter(fmt.Sprintf("name eq '%s'", name)))
 	if err != nil {
@@ -75,18 +79,63 @@ func findImageByNameHelper(ctx context.Context, client *convergedv4.Client, name
 		}
 	}
 
-	if len(found) > 1 {
-		return nil, fmt.Errorf("found more than one image with name %s", name)
-	}
-
 	if len(found) == 0 {
 		return nil, fmt.Errorf("image %s not found", name)
+	}
+
+	if len(found) > 1 {
+		log.Printf("WARNING: found %d images with name '%s', selecting the newest ready image", len(found), name)
+		found = selectNewestReadyImage(found)
+		if len(found) == 0 {
+			return nil, fmt.Errorf("found multiple images with name '%s' but none are ready (SizeBytes > 0)", name)
+		}
 	}
 
 	if found[0].ExtId == nil {
 		return nil, fmt.Errorf("image %s has no ExtId", name)
 	}
 	return findImageByUUIDHelper(ctx, client, *found[0].ExtId)
+}
+
+// sortImagesByCreateTimeDesc sorts images by CreateTime in descending order
+// (newest first). Images without CreateTime are sorted to the end.
+func sortImagesByCreateTimeDesc(images []*imageModels.Image) {
+	sort.Slice(images, func(i, j int) bool {
+		if images[i].CreateTime == nil || images[j].CreateTime == nil {
+			return images[i].CreateTime != nil
+		}
+		return images[i].CreateTime.After(*images[j].CreateTime)
+	})
+}
+
+// selectNewestReadyImage filters to ready images (SizeBytes > 0) and sorts by
+// CreateTime descending so the newest image is first. Returns the filtered and
+// sorted slice (may be empty if no images are ready).
+func selectNewestReadyImage(images []*imageModels.Image) []*imageModels.Image {
+	ready := make([]*imageModels.Image, 0, len(images))
+	for _, img := range images {
+		if img.SizeBytes != nil && *img.SizeBytes > 0 {
+			ready = append(ready, img)
+		} else {
+			extId := ""
+			if img.ExtId != nil {
+				extId = *img.ExtId
+			}
+			log.Printf("skipping image '%s' (extId: %s) - not ready (SizeBytes: %v)", *img.Name, extId, img.SizeBytes)
+		}
+	}
+
+	if len(ready) <= 1 {
+		return ready
+	}
+
+	sortImagesByCreateTimeDesc(ready)
+
+	selected := ready[0]
+	log.Printf("selected newest image '%s' (extId: %s, created: %v) from %d candidates",
+		*selected.Name, *selected.ExtId, selected.CreateTime, len(ready))
+
+	return ready[:1]
 }
 
 // Cluster helpers

--- a/docs/builders/nutanix.mdx
+++ b/docs/builders/nutanix.mdx
@@ -71,6 +71,7 @@ These parameters allow to configure everything around image creation, from the t
 - `image_skip` (bool) - Skip image creation (default is false).
 - `image_export` (bool) - Export raw image in the current folder (default is false).
 - `fail_if_image_exists` (bool) - Fail the build if an image with the same name already exists (default is false).
+- `allow_duplicate_images` (bool) - When `true`, the plugin tolerates multiple images with the same name in the Prism Central image library. Instead of failing, it selects the newest ready image. This is useful in parallel CI environments where concurrent builds may create images with identical names. When `false` (the default), the plugin returns an error if more than one image matches by name, which is the recommended behavior for production systems.
 - `shutdown_command` (string) - Command line to shutdown your temporary VM.
 - `shutdown_timeout` (string) - Timeout for VM shutdown (format : 2m).
 - `vm_force_delete` (bool) - Delete vm even if build is not succesful (default is false).


### PR DESCRIPTION
## Summary

- When multiple images share the same name in Prism Central (common during parallel CI runs), the plugin now selects the newest ready image instead of returning a fatal error like `"found more than one image with name X"`.
- Affected functions: `findImageByNameHelper` (used by all name-based image lookups) and `sourceImageExists` (used when checking if a URL-sourced image already exists).
- No behavioral change when image names are unique (single match works exactly as before).

## Problem

Nutanix image names are **not unique identifiers** — only UUIDs are. When parallel CI jobs create or reference images with identical names, the plugin hard-failed because it expected name lookups to return exactly one result. This was blocking Rocky Linux image builds and daily cluster build CI jobs (NCN-114585).

## What Changed

**`builder/nutanix/helpers.go`**
- `findImageByNameHelper`: On duplicate names, filters to ready images (`SizeBytes > 0`), sorts by `CreateTime` descending, and returns the newest.
- New helpers: `sortImagesByCreateTimeDesc` and `selectNewestReadyImage`.

**`builder/nutanix/driver.go`**
- `sourceImageExists`: When multiple images match by URL or name, selects the newest instead of erroring. Logs a warning for visibility.

### End-to-end Packer build
- [x] **Created two images with identical name** `packer-e2e-dupe-test` via v3 API (UUIDs: `fd2393e8`, `052755e5`)
- [x] **Ran full `packer build`** with `source_image_name = "packer-e2e-dupe-test"` — plugin logged `WARNING: found 2 images with name 'packer-e2e-dupe-test', selecting the newest ready image`, selected the newer one (extId: `052755e5`), and successfully created the VM
- [x] **Confirmed old plugin fails** — same config with the unpatched plugin returned fatal error: `found more than one image with name packer-e2e-dupe-test`


Ref: NCN-114585