### PR TITLE
chore(deps): bump prism-go-client from v0.7.2 to v0.7.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/packer-plugin-sdk v0.6.8
 	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
-	github.com/nutanix-cloud-native/prism-go-client v0.7.2
+	github.com/nutanix-cloud-native/prism-go-client v0.7.3
 	github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.2.2
 	github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4 v4.3.1
 	github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4 v4.2.2

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
-github.com/nutanix-cloud-native/prism-go-client v0.7.2 h1:iJJYBiim1KnzQwSIv9JFr74qNnyy3u/2gtihVR14HOo=
-github.com/nutanix-cloud-native/prism-go-client v0.7.2/go.mod h1:vsSt2UviUrayZXh0yubhtL++LJ+LHvr7sREw9aG0STw=
+github.com/nutanix-cloud-native/prism-go-client v0.7.3 h1:VDeeXg/ntqtruQC4ZEESqxfDCSEEY7N0JtR4kNq/WRk=
+github.com/nutanix-cloud-native/prism-go-client v0.7.3/go.mod h1:vsSt2UviUrayZXh0yubhtL++LJ+LHvr7sREw9aG0STw=
 github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.2.2 h1:IctWgmfEJEKX5UL8NOLylPQwM5quK8tbbZF4BuSuSwE=
 github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4 v4.2.2/go.mod h1:c52CmT116rC0iLmS11iiTy2cg+j+ifP0X8ZIHwNVefI=
 github.com/nutanix/ntnx-api-golang-clients/datapolicies-go-client/v4 v4.2.1 h1:gWgUofXXGdXHCBgz3fG7WeQ6dDp4RFUG3kRY8/X0DHY=


### PR DESCRIPTION
Bump prism-go-client from v0.7.2 to v0.7.3
Avoids leaking host AWS credentials into Nutanix Objects Lite S3 uploads, preventing unintended authentication against wrong endpoints