### PR TITLE
chore: update Nutanix plugin version from 1.1.7 to 1.1.8 in documenta…

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.7"
+      version = ">= 1.1.8"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.7"
+      version = ">= 1.1.8"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.7"
+      version = ">= 1.1.8"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/example/plugin.pkr.hcl
+++ b/example/plugin.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.7"
+      version = ">= 1.1.8"
       source = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.1.7"
+	Version = "1.1.8"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
Bump Nutanix plugin version from 1.1.7 to 1.1.8 across documentation and code
Updated version references in version/version.go, README.md, docs/README.md, .web-docs/README.md, and example/plugin.pkr.hcl
