### PR TITLE
fix: honour context cancellation in WaitForIP so ip_wait_timeout is enforced

### DIFF
--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -889,6 +889,17 @@ func (d *NutanixDriver) WaitForIP(ctx context.Context, vmUUID string, ipNet *net
 	var IPAddress string
 
 	for {
+		// Bail out immediately if the wait was cancelled (ip_wait_timeout fired,
+		// or the build was interrupted). The v4 SDK's VMs.Get does not honour the
+		// context, so without this explicit check the loop would never observe the
+		// cancellation and the caller's `<-waitDone` would block until an IP is
+		// found (i.e. potentially forever for a VM that never gets one).
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+
 		vm, err := v4Client.VMs.Get(ctx, vmUUID)
 		if err != nil {
 			log.Printf("error getting vm: %s", err.Error())
@@ -930,7 +941,13 @@ func (d *NutanixDriver) WaitForIP(ctx context.Context, vmUUID string, ipNet *net
 			}
 		}
 
-		time.Sleep(5 * time.Second)
+		// Cancellable backoff: wake early if the wait is cancelled rather than
+		// sleeping through the full interval and only noticing on the next loop.
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
 	}
 
 	log.Printf("VM (%s) configured with ip address %s", vmUUID, IPAddress)


### PR DESCRIPTION
Closes #404.

## Problem

`ip_wait_timeout` (default `30m`) does not actually bound the "Waiting for IP..." phase. A VM that never obtains an IP (DHCP exhaustion, NIC misconfig, PXE/WinPE boot failure, guest agent never starting) hangs the build until the **outer** Packer/CI timeout SIGKILLs it — which skips `-on-error=cleanup` and leaks the powered-on build VM (still holding its DHCP lease, compounding the exhaustion that may have caused the hang).

## Root cause

Two layers conspire:

1. **`stepWaitForIp.Run`** — when `ip_wait_timeout` fires it calls `cancel()` and then **blocks on `<-waitDone`**, so it cannot return `ActionHalt` until the polling goroutine returns.
2. **`WaitForIP` (`driver.go`)** — its poll loop has **no `ctx.Done()` check** and uses a plain, uninterruptible `time.Sleep(5 * time.Second)`. It only returns on IP-found or when `v4Client.VMs.Get(ctx, …)` returns an error.

The catch: the converged v4 SDK's `VMs.Get(ctx, …)` **accepts a context but discards it** — it calls the generated `VmApi.GetVmById(&uuid)`, which takes no context at all (confirmed in prism-go-client v0.7.2 and v0.7.3). So cancelling the wait can never make the loop exit, `<-waitDone` never unblocks, and the timeout is effectively cosmetic for the no-IP case.

## Fix

Make `WaitForIP`'s loop honour the context, independent of SDK behaviour:

- An explicit `ctx.Done()` check at the top of the loop.
- A cancellable `select { case <-ctx.Done(): … case <-time.After(5 * time.Second): }` backoff in place of the bare `time.Sleep`.

When `ip_wait_timeout` fires (or the build is interrupted), the loop now returns `ctx.Err()` promptly → the goroutine returns → `<-waitDone` unblocks → `Run` returns `ActionHalt` → `-on-error=cleanup` deletes the VM. The fix is self-sufficient: it does not depend on whether the SDK ever starts honouring the context.

## Testing

- `go build ./...` and `go vet ./builder/...` pass.
- Manual reasoning / inspection: the two `ctx.Done()` checks guarantee a bounded exit between polls regardless of `VMs.Get` behaviour.

No automated test is included: `WaitForIP` requires a live v4 client (`getV4Client()`) and `stepWaitForIp.Run` casts to the concrete `*NutanixDriver` (`WaitForIP` isn't part of the `Driver` interface), so exercising the cancellation path would require mock infrastructure that doesn't exist in the repo today. Happy to add a testable seam + unit test in a follow-up if maintainers would like one.

## Note on the same pattern elsewhere

The same uninterruptible `time.Sleep(5 * time.Second)` poll appears in the image-readiness loops in `driver.go`, but those are bounded by a retry counter (~60s) so they terminate and don't leak. Left untouched here to keep this fix focused; can give them the same `ctx.Done()` treatment in a follow-up if desired.

