### PR TITLE
chore: update Nutanix plugin version from 1.1.8 to 1.1.9 in code and documentation

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.8"
+      version = ">= 1.1.9"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/.web-docs/components/builder/nutanix/README.md
+++ b/.web-docs/components/builder/nutanix/README.md
@@ -312,7 +312,11 @@ command, they will be replaced by the proper key:
 
 -   `<leftShift> <rightShift>` - Simulates pressing the shift key.
 
--   `<leftSuper> <rightSuper>` - Simulates pressing the ⌘ or Windows key.
+-   `<leftSuper> <rightSuper>` - Simulates pressing the super key.
+
+-   `<leftCommand> <rightCommand>` - Simulates pressing the ⌘ key.
+
+-   `<leftOption> <rightOption>` - Simulates pressing the ⌥ key.
 
   - `<wait> <wait5> <wait10>` - Adds a 1, 5 or 10 second pause before
     sending any additional keys. This is useful if you have to generally

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then, run [`packer init`](https://www.packer.io/docs/commands/init).
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.8"
+      version = ">= 1.1.9"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ To install this plugin, copy and paste this code into your Packer configuration,
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.8"
+      version = ">= 1.1.9"
       source  = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/example/plugin.pkr.hcl
+++ b/example/plugin.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 1.1.8"
+      version = ">= 1.1.9"
       source = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.1.8"
+	Version = "1.1.9"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
This pull request updates the Nutanix Packer plugin to version 1.1.9 and improves documentation for keyboard key simulation. The main changes are version bumps across configuration and documentation files, and clarification/addition of key simulation instructions.

**Version bump to 1.1.9:**
* Updated the Nutanix plugin version requirement from 1.1.8 to 1.1.9 in all relevant config and documentation files: `example/plugin.pkr.hcl`, `.web-docs/README.md`, `docs/README.md`, `README.md` [[1]](diffhunk://#diff-76b6307bdd2d08982de7b5cc50f57161e4782a183d7886ec64f5b3f869e86b29L4-R4) [[2]](diffhunk://#diff-d240320fc87f7ae14f8d7a62c2cd1db6f4676aa33fa78d3c48a1d3d9c4c550c8L12-R12) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35).
* Updated the main plugin version in `version/version.go` to 1.1.9.

**Documentation improvements for keyboard simulation:**
* Clarified that `<leftSuper>` and `<rightSuper>` simulate the "super" key, and added new entries for `<leftCommand>`/`<rightCommand>` (⌘ key) and `<leftOption>`/`<rightOption>` (⌥ key) in `.web-docs/components/builder/nutanix/README.md`.