### PR TITLE
feat(template): support updating existing templates (guest update)

### DIFF
--- a/builder/nutanix/builder.go
+++ b/builder/nutanix/builder.go
@@ -55,72 +55,101 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	// so we put it in the state bag to be used by the cleanup step
 	state.Put("ctx", ctx)
 
-	steps := []multistep.Step{
-		&commonsteps.StepCreateCD{
-			Files:   b.config.CDConfig.CDFiles,
-			Content: b.config.CDConfig.CDContent,
-			Label:   b.config.CDConfig.CDLabel,
-		},
-		&stepBuildVM{},
-		&stepVNCConnect{
-			Config: &b.config,
-		},
-		&stepVNCBootCommand{
-			Config: &b.config,
-		},
-		&stepWaitForIp{
-			Config: &b.config.WaitIpConfig,
-		},
-		&communicator.StepConnect{
-			Config:    &b.config.Comm,
-			SSHConfig: b.config.Comm.SSHConfigFunc(),
-			Host:      commHost(b.config.Comm.Host()),
-		},
-		new(commonsteps.StepProvision),
-		&StepShutdown{
-			Command:             b.config.ShutdownCommand,
-			Timeout:             b.config.ShutdownTimeout,
-			DisableStopInstance: b.config.DisableStopInstance,
-		},
-	}
+	var steps []multistep.Step
 
-	if b.config.Clean.Cdrom {
-		steps = append(steps, &stepCleanVM{
-			Config: &b.config,
-		})
-	}
+	if b.config.TemplateConfig.UpdateTemplate {
+		// Template update flow: initiate guest update -> provision -> shutdown -> complete
+		steps = []multistep.Step{
+			&stepInitiateGuestUpdate{
+				Config: &b.config,
+			},
+			&stepWaitForIp{
+				Config: &b.config.WaitIpConfig,
+			},
+			&communicator.StepConnect{
+				Config:    &b.config.Comm,
+				SSHConfig: b.config.Comm.SSHConfigFunc(),
+				Host:      commHost(b.config.Comm.Host()),
+			},
+			new(commonsteps.StepProvision),
+			&StepShutdown{
+				Command:             b.config.ShutdownCommand,
+				Timeout:             b.config.ShutdownTimeout,
+				DisableStopInstance: b.config.DisableStopInstance,
+			},
+			&stepCompleteGuestUpdate{
+				Config: &b.config,
+			},
+		}
+	} else {
+		// Normal build flow: create VM -> VNC -> provision -> shutdown -> create image/template/OVA
+		steps = []multistep.Step{
+			&commonsteps.StepCreateCD{
+				Files:   b.config.CDConfig.CDFiles,
+				Content: b.config.CDConfig.CDContent,
+				Label:   b.config.CDConfig.CDLabel,
+			},
+			&stepBuildVM{},
+			&stepVNCConnect{
+				Config: &b.config,
+			},
+			&stepVNCBootCommand{
+				Config: &b.config,
+			},
+			&stepWaitForIp{
+				Config: &b.config.WaitIpConfig,
+			},
+			&communicator.StepConnect{
+				Config:    &b.config.Comm,
+				SSHConfig: b.config.Comm.SSHConfigFunc(),
+				Host:      commHost(b.config.Comm.Host()),
+			},
+			new(commonsteps.StepProvision),
+			&StepShutdown{
+				Command:             b.config.ShutdownCommand,
+				Timeout:             b.config.ShutdownTimeout,
+				DisableStopInstance: b.config.DisableStopInstance,
+			},
+		}
 
-	if !b.config.ImageSkip {
-		steps = append(steps, &stepCreateImage{
-			Config: &b.config,
-		})
-	}
+		if b.config.Clean.Cdrom {
+			steps = append(steps, &stepCleanVM{
+				Config: &b.config,
+			})
+		}
 
-	if b.config.ImageExport {
-		steps = append(steps, &stepExportImage{
-			VMName:    b.config.VMName,
-			ImageName: b.config.VmConfig.ImageName,
-		})
-	}
+		if !b.config.ImageSkip {
+			steps = append(steps, &stepCreateImage{
+				Config: &b.config,
+			})
+		}
 
-	if b.config.TemplateConfig.Create {
-		steps = append(steps, &stepCreateTemplate{
-			Config: &b.config,
-		})
-	}
+		if b.config.ImageExport {
+			steps = append(steps, &stepExportImage{
+				VMName:    b.config.VMName,
+				ImageName: b.config.VmConfig.ImageName,
+			})
+		}
 
-	if b.config.OvaConfig.Create {
-		steps = append(steps, &StepCreateOVA{
-			VMName:    b.config.VMName,
-			OvaConfig: b.config.OvaConfig,
-		})
-	}
+		if b.config.TemplateConfig.Create {
+			steps = append(steps, &stepCreateTemplate{
+				Config: &b.config,
+			})
+		}
 
-	if b.config.OvaConfig.Export {
-		steps = append(steps, &StepExportOVA{
-			VMName:    b.config.VMName,
-			OvaConfig: b.config.OvaConfig,
-		})
+		if b.config.OvaConfig.Create {
+			steps = append(steps, &StepCreateOVA{
+				VMName:    b.config.VMName,
+				OvaConfig: b.config.OvaConfig,
+			})
+		}
+
+		if b.config.OvaConfig.Export {
+			steps = append(steps, &StepExportOVA{
+				VMName:    b.config.VMName,
+				OvaConfig: b.config.OvaConfig,
+			})
+		}
 	}
 
 	b.runner = commonsteps.NewRunnerWithPauseFn(steps, b.config.PackerConfig, ui, state)

--- a/builder/nutanix/config.go
+++ b/builder/nutanix/config.go
@@ -148,9 +148,13 @@ type OvaConfig struct {
 }
 
 type TemplateConfig struct {
-	Create      bool   `mapstructure:"create" json:"create" required:"false"`
-	Name        string `mapstructure:"name" json:"name" required:"false"`
-	Description string `mapstructure:"description" json:"description" required:"false"`
+	Create             bool   `mapstructure:"create" json:"create" required:"false"`
+	UpdateTemplate     bool   `mapstructure:"update_template" json:"update_template" required:"false"`
+	ExtID              string `mapstructure:"ext_id" json:"ext_id" required:"false"`
+	Name               string `mapstructure:"name" json:"name" required:"false"`
+	Description        string `mapstructure:"description" json:"description" required:"false"`
+	VersionName        string `mapstructure:"version_name" json:"version_name" required:"false"`
+	VersionDescription string `mapstructure:"version_description" json:"version_description" required:"false"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
@@ -232,6 +236,20 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("missing nutanix_endpoint"))
 	}
 
+	// Validate template.create and template.update_template are mutually exclusive
+	if c.TemplateConfig.Create && c.TemplateConfig.UpdateTemplate {
+		log.Println("template.create and template.update_template are mutually exclusive")
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("template.create and template.update_template are mutually exclusive"))
+	}
+
+	// When update_template is set, either ext_id or name must be provided
+	if c.TemplateConfig.UpdateTemplate {
+		if c.TemplateConfig.ExtID == "" && c.TemplateConfig.Name == "" {
+			log.Println("template.update_template requires either template.ext_id or template.name")
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("template.update_template requires either template.ext_id or template.name"))
+		}
+	}
+
 	// When trying to export OVA, it should always be created
 	if c.OvaConfig.Export && !c.OvaConfig.Create {
 		log.Println("Setting ova.create to 'true', because ova.export is 'true'")
@@ -268,8 +286,8 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("missing cluster_name or cluster_uuid"))
 	}
 
-	// Validate VM disks
-	if len(c.VmConfig.VmDisks) == 0 {
+	// Validate VM disks (not required when updating an existing template)
+	if len(c.VmConfig.VmDisks) == 0 && !c.TemplateConfig.UpdateTemplate {
 		log.Println("Nutanix VM Disks missing from configuration")
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("missing vm_disks"))
 	}

--- a/builder/nutanix/config.hcl2spec.go
+++ b/builder/nutanix/config.hcl2spec.go
@@ -361,9 +361,13 @@ func (*FlatOvaConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatTemplateConfig is an auto-generated flat version of TemplateConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatTemplateConfig struct {
-	Create      *bool   `mapstructure:"create" json:"create" required:"false" cty:"create" hcl:"create"`
-	Name        *string `mapstructure:"name" json:"name" required:"false" cty:"name" hcl:"name"`
-	Description *string `mapstructure:"description" json:"description" required:"false" cty:"description" hcl:"description"`
+	Create             *bool   `mapstructure:"create" json:"create" required:"false" cty:"create" hcl:"create"`
+	UpdateTemplate     *bool   `mapstructure:"update_template" json:"update_template" required:"false" cty:"update_template" hcl:"update_template"`
+	ExtID              *string `mapstructure:"ext_id" json:"ext_id" required:"false" cty:"ext_id" hcl:"ext_id"`
+	Name               *string `mapstructure:"name" json:"name" required:"false" cty:"name" hcl:"name"`
+	Description        *string `mapstructure:"description" json:"description" required:"false" cty:"description" hcl:"description"`
+	VersionName        *string `mapstructure:"version_name" json:"version_name" required:"false" cty:"version_name" hcl:"version_name"`
+	VersionDescription *string `mapstructure:"version_description" json:"version_description" required:"false" cty:"version_description" hcl:"version_description"`
 }
 
 // FlatMapstructure returns a new FlatTemplateConfig.
@@ -378,9 +382,13 @@ func (*TemplateConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hclde
 // The decoded values from this spec will then be applied to a FlatTemplateConfig.
 func (*FlatTemplateConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"create":      &hcldec.AttrSpec{Name: "create", Type: cty.Bool, Required: false},
-		"name":        &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
-		"description": &hcldec.AttrSpec{Name: "description", Type: cty.String, Required: false},
+		"create":              &hcldec.AttrSpec{Name: "create", Type: cty.Bool, Required: false},
+		"update_template":     &hcldec.AttrSpec{Name: "update_template", Type: cty.Bool, Required: false},
+		"ext_id":              &hcldec.AttrSpec{Name: "ext_id", Type: cty.String, Required: false},
+		"name":                &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
+		"description":         &hcldec.AttrSpec{Name: "description", Type: cty.String, Required: false},
+		"version_name":        &hcldec.AttrSpec{Name: "version_name", Type: cty.String, Required: false},
+		"version_description": &hcldec.AttrSpec{Name: "version_description", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/nutanix/driver.go
+++ b/builder/nutanix/driver.go
@@ -64,6 +64,10 @@ type Driver interface {
 	CleanCD(context.Context, string) error
 	PowerOn(context.Context, string) error
 	GenerateConsoleToken(context.Context, string) (token, wsUri string, err error)
+	FindTemplateByName(ctx context.Context, name string) (extID string, err error)
+	InitiateGuestUpdate(ctx context.Context, templateExtID string, versionID string) (vmUUID string, err error)
+	CompleteGuestUpdate(ctx context.Context, templateExtID string, versionName string, versionDescription string) error
+	CancelGuestUpdate(ctx context.Context, templateExtID string) error
 }
 
 // Verify that NutanixDriver implements the Driver interface
@@ -1205,6 +1209,91 @@ func (d *NutanixDriver) CreateTemplate(ctx context.Context, vmUUID string, templ
 	}
 
 	log.Printf("Template %s created successfully", templateConfig.Name)
+	return nil
+}
+
+// FindTemplateByName looks up a template by name using the V4 API filter.
+// Returns the template ext ID if exactly one match is found; errors on 0 or >1.
+func (d *NutanixDriver) FindTemplateByName(ctx context.Context, name string) (string, error) {
+	v4Client, err := d.getV4Client()
+	if err != nil {
+		return "", fmt.Errorf("error creating V4 client: %w", err)
+	}
+
+	filter := fmt.Sprintf("templateName eq '%s'", name)
+	templates, err := v4Client.Templates.List(ctx, converged.WithFilter(filter))
+	if err != nil {
+		return "", fmt.Errorf("error listing templates with filter %q: %w", filter, err)
+	}
+
+	if len(templates) == 0 {
+		return "", fmt.Errorf("no template found with name %q", name)
+	}
+	if len(templates) > 1 {
+		return "", fmt.Errorf("found %d templates with name %q; use template.ext_id to specify which one", len(templates), name)
+	}
+
+	if templates[0].ExtId == nil {
+		return "", fmt.Errorf("template %q has nil ExtId", name)
+	}
+	return *templates[0].ExtId, nil
+}
+
+// InitiateGuestUpdate starts a guest OS update for the given template, creating
+// a temporary VM. Returns the temporary VM UUID.
+func (d *NutanixDriver) InitiateGuestUpdate(ctx context.Context, templateExtID string, versionID string) (string, error) {
+	v4Client, err := d.getV4Client()
+	if err != nil {
+		return "", fmt.Errorf("error creating V4 client: %w", err)
+	}
+
+	log.Printf("Initiating guest update for template %s", templateExtID)
+	template, err := v4Client.Templates.InitiateGuestUpdate(ctx, templateExtID, versionID)
+	if err != nil {
+		return "", fmt.Errorf("error initiating guest update: %w", err)
+	}
+
+	if template.GuestUpdateStatus == nil || template.GuestUpdateStatus.DeployedVmReference == nil {
+		return "", fmt.Errorf("guest update initiated but no temporary VM reference returned")
+	}
+
+	vmUUID := *template.GuestUpdateStatus.DeployedVmReference
+	log.Printf("Guest update initiated, temporary VM UUID: %s", vmUUID)
+	return vmUUID, nil
+}
+
+// CompleteGuestUpdate finalizes a guest OS update, creating a new template version.
+func (d *NutanixDriver) CompleteGuestUpdate(ctx context.Context, templateExtID string, versionName string, versionDescription string) error {
+	v4Client, err := d.getV4Client()
+	if err != nil {
+		return fmt.Errorf("error creating V4 client: %w", err)
+	}
+
+	log.Printf("Completing guest update for template %s", templateExtID)
+	isActive := true
+	_, err = v4Client.Templates.CompleteGuestUpdate(ctx, templateExtID, versionName, versionDescription, isActive)
+	if err != nil {
+		return fmt.Errorf("error completing guest update: %w", err)
+	}
+
+	log.Printf("Guest update completed for template %s, new version: %s", templateExtID, versionName)
+	return nil
+}
+
+// CancelGuestUpdate aborts an in-progress guest OS update on the template.
+func (d *NutanixDriver) CancelGuestUpdate(ctx context.Context, templateExtID string) error {
+	v4Client, err := d.getV4Client()
+	if err != nil {
+		return fmt.Errorf("error creating V4 client: %w", err)
+	}
+
+	log.Printf("Cancelling guest update for template %s", templateExtID)
+	err = v4Client.Templates.CancelGuestUpdate(ctx, templateExtID)
+	if err != nil {
+		return fmt.Errorf("error cancelling guest update: %w", err)
+	}
+
+	log.Printf("Guest update cancelled for template %s", templateExtID)
 	return nil
 }
 

--- a/builder/nutanix/step_complete_guest_update.go
+++ b/builder/nutanix/step_complete_guest_update.go
@@ -1,0 +1,42 @@
+package nutanix
+
+import (
+	"context"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type stepCompleteGuestUpdate struct {
+	Config *Config
+}
+
+func (s *stepCompleteGuestUpdate) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	d := state.Get("driver").(Driver)
+	templateExtID := state.Get("template_ext_id").(string)
+
+	versionName := s.Config.TemplateConfig.VersionName
+	if versionName == "" {
+		versionName = "packer-built"
+	}
+
+	versionDescription := s.Config.TemplateConfig.VersionDescription
+
+	ui.Sayf("Completing guest update for template %s (version: %s)...", templateExtID, versionName)
+	err := d.CompleteGuestUpdate(ctx, templateExtID, versionName, versionDescription)
+	if err != nil {
+		ui.Error("Failed to complete guest update: " + err.Error())
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	// Clear the initiated flag so cleanup doesn't try to cancel
+	state.Put("guest_update_initiated", false)
+
+	ui.Sayf("Template %s updated successfully, new version: %s", templateExtID, versionName)
+	return multistep.ActionContinue
+}
+
+func (s *stepCompleteGuestUpdate) Cleanup(state multistep.StateBag) {
+}

--- a/builder/nutanix/step_initiate_guest_update.go
+++ b/builder/nutanix/step_initiate_guest_update.go
@@ -1,0 +1,92 @@
+package nutanix
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type stepInitiateGuestUpdate struct {
+	Config *Config
+}
+
+func (s *stepInitiateGuestUpdate) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	d := state.Get("driver").(Driver)
+
+	templateExtID := s.Config.TemplateConfig.ExtID
+
+	// Resolve template ext ID from name if not provided directly
+	if templateExtID == "" {
+		ui.Sayf("Looking up template by name %q...", s.Config.TemplateConfig.Name)
+		extID, err := d.FindTemplateByName(ctx, s.Config.TemplateConfig.Name)
+		if err != nil {
+			ui.Error("Failed to find template: " + err.Error())
+			state.Put("error", err)
+			return multistep.ActionHalt
+		}
+		templateExtID = extID
+		ui.Sayf("Found template ext ID: %s", templateExtID)
+	}
+
+	state.Put("template_ext_id", templateExtID)
+
+	ui.Sayf("Initiating guest update for template %s...", templateExtID)
+	vmUUID, err := d.InitiateGuestUpdate(ctx, templateExtID, "")
+	if err != nil {
+		ui.Error("Failed to initiate guest update: " + err.Error())
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	state.Put("guest_update_initiated", true)
+	state.Put("vm_uuid", vmUUID)
+
+	ui.Sayf("Temporary VM created: %s", vmUUID)
+
+	// Power on the temporary VM so provisioners can connect
+	ui.Say("Powering on temporary VM...")
+	if err := d.PowerOn(ctx, vmUUID); err != nil {
+		ui.Error("Failed to power on temporary VM: " + err.Error())
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	ui.Say("Temporary VM is powered on and ready for provisioning")
+	return multistep.ActionContinue
+}
+
+func (s *stepInitiateGuestUpdate) Cleanup(state multistep.StateBag) {
+	_, initiated := state.GetOk("guest_update_initiated")
+	if !initiated {
+		return
+	}
+
+	_, cancelled := state.GetOk(multistep.StateCancelled)
+	_, halted := state.GetOk(multistep.StateHalted)
+	if !cancelled && !halted {
+		return
+	}
+
+	templateExtID, ok := state.Get("template_ext_id").(string)
+	if !ok || templateExtID == "" {
+		return
+	}
+
+	ui := state.Get("ui").(packer.Ui)
+	d := state.Get("driver").(Driver)
+	ctx, ok := state.Get("ctx").(context.Context)
+	if !ok {
+		ctx = context.Background()
+	}
+
+	ui.Say("Build failed or cancelled, cancelling guest update...")
+	err := d.CancelGuestUpdate(ctx, templateExtID)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Warning: failed to cancel guest update: %s", err.Error()))
+	} else {
+		ui.Say("Guest update cancelled, temporary VM removed")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces support for updating existing Nutanix templates
(creating a new version) via the "guest update" workflow.
 
Previously, the plugin only supported creating new templates even if
"packer build" was run with the exact same set of parameters.

With this change, users can specify `update_template = true` along
with the template `name` or `ext_id`. Packer will provision a temporary
VM from the existing template, run provisioners, and save the result as
a new template version.

**Which issue(s) this PR fixes**
Fixes #302

**How Has This Been Tested?**:

To be fair, so far testing was manual with following piece of configuration
present in build.nutanix.pkr.hcl:

```
template {
  update_template   = true | false
  create            = true | false
  ext_id            = "ea06ce5c-c864-4e70-affa-8bfee7047094"
  name              = "debian-template"
  description       = "Debian 13 Template"
}
```

**Special notes for your reviewer**:

**Blocked by upstream:**
This PR relies on new methods in [prism-go-client](https://github.com/nutanix-cloud-native/prism-go-client/pull/365)
which are currently in review. Once the client changes are merged and released,
`go.mod` will need to be updated to the new version before this PR can be merged.


**Release note**:
```release-note
NONE
```
