### PR TITLE
docs: document release-tag mapping for pre-v4 and post-v4 API

### DIFF
--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -26,8 +26,10 @@ $ packer plugins install github.com/nutanix-cloud-native/nutanix
 
 This plugin currently has two maintained release lines:
 
-- `release-1.2`: clean cut before the v4 API migration.
-- `main`: post-v4 API migration changes and the latest line.
+- `release-1.2`: clean cut before the v4 API migration, created from the `v1.1.4` baseline.
+- `main`: post-v4 API migration changes and the latest line. `v1.3.0` was introduced from the latest `1.1.x` baseline, and subsequent `v1.3.x` releases are cut from `main`.
+
+This structure preserves pre-v4 API compatibility, keeps release ownership clear for maintainers, and allows current development to continue on the post-v4 line.
 
 Going forward, release tags are created from the corresponding branch lines:
 

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -27,7 +27,7 @@ $ packer plugins install github.com/nutanix-cloud-native/nutanix
 This plugin currently has two maintained release lines:
 
 - `release-1.2`: clean cut before the v4 API migration, created from the `v1.1.4` baseline.
-- `main`: post-v4 API migration changes and the latest line. `v1.3.0` was introduced from the latest `1.1.x` baseline, and subsequent `v1.3.x` releases are cut from `main`.
+- `main`: post-v4 API migration changes and the latest line. `v1.3.0` was introduced from the `1.1.10` baseline, and subsequent `v1.3.x` releases are cut from `main`.
 
 This structure preserves pre-v4 API compatibility, keeps release ownership clear for maintainers, and allows current development to continue on the post-v4 line.
 

--- a/.web-docs/README.md
+++ b/.web-docs/README.md
@@ -22,6 +22,18 @@ Alternatively, you can use `packer plugins install` to manage installation of th
 $ packer plugins install github.com/nutanix-cloud-native/nutanix
 ```
 
+### Release Branches and Version Lineage
+
+This plugin currently has two maintained release lines:
+
+- `release-1.2`: clean cut before the v4 API migration.
+- `main`: post-v4 API migration changes and the latest line.
+
+Going forward, release tags are created from the corresponding branch lines:
+
+- `v1.2.x` tags from `release-1.2` (pre-v4 API).
+- `v1.3.x` tags from `main` (post-v4 API, latest line).
+
 ### Components
 
 #### Builders

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To install the compiled plugin, please follow the official Packer documentation 
 This repository maintains two release lines with explicit API scope:
 
 - `release-1.2`: clean cut before the v4 API migration, created from the `v1.1.4` baseline.
-- `main`: post-v4 API migration changes and the latest line. `v1.3.0` was introduced from the latest `1.1.x` baseline, and subsequent `v1.3.x` releases are cut from `main`.
+- `main`: post-v4 API migration changes and the latest line. `v1.3.0` was introduced from the `1.1.10` baseline, and subsequent `v1.3.x` releases are cut from `main`.
 
 This structure preserves pre-v4 API compatibility, keeps release ownership clear for maintainers, and allows current development to continue on the post-v4 line.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ If you prefer to build the plugin from its source code, clone the GitHub reposit
 Upon successful compilation, a `packer-plugin-nutanix` plugin binary file can be found in the root directory.
 To install the compiled plugin, please follow the official Packer documentation on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
 
+## Release Branches and Version Lineage
+
+This repository maintains two release lines with explicit API scope:
+
+- `release-1.2`: clean cut before the v4 API migration.
+- `main`: post-v4 API migration changes and the latest line.
+
+Going forward, release tags are created from the corresponding branch lines:
+
+- `v1.2.x` tags from `release-1.2` (pre-v4 API).
+- `v1.3.x` tags from `main` (post-v4 API, latest line).
+
 ### Configuration
 
 For more information on how to configure the plugin, please find some examples in the  [`example/`](example) directory.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ To install the compiled plugin, please follow the official Packer documentation 
 
 This repository maintains two release lines with explicit API scope:
 
-- `release-1.2`: clean cut before the v4 API migration.
-- `main`: post-v4 API migration changes and the latest line.
+- `release-1.2`: clean cut before the v4 API migration, created from the `v1.1.4` baseline.
+- `main`: post-v4 API migration changes and the latest line. `v1.3.0` was introduced from the latest `1.1.x` baseline, and subsequent `v1.3.x` releases are cut from `main`.
+
+This structure preserves pre-v4 API compatibility, keeps release ownership clear for maintainers, and allows current development to continue on the post-v4 line.
 
 Going forward, release tags are created from the corresponding branch lines:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,8 +26,10 @@ $ packer plugins install github.com/nutanix-cloud-native/nutanix
 
 This plugin currently has two maintained release lines:
 
-- `release-1.2`: clean cut before the v4 API migration.
-- `main`: post-v4 API migration changes and the latest line.
+- `release-1.2`: clean cut before the v4 API migration, created from the `v1.1.4` baseline.
+- `main`: post-v4 API migration changes and the latest line. `v1.3.0` was introduced from the latest `1.1.x` baseline, and subsequent `v1.3.x` releases are cut from `main`.
+
+This structure preserves pre-v4 API compatibility, keeps release ownership clear for maintainers, and allows current development to continue on the post-v4 line.
 
 Going forward, release tags are created from the corresponding branch lines:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ $ packer plugins install github.com/nutanix-cloud-native/nutanix
 This plugin currently has two maintained release lines:
 
 - `release-1.2`: clean cut before the v4 API migration, created from the `v1.1.4` baseline.
-- `main`: post-v4 API migration changes and the latest line. `v1.3.0` was introduced from the latest `1.1.x` baseline, and subsequent `v1.3.x` releases are cut from `main`.
+- `main`: post-v4 API migration changes and the latest line. `v1.3.0` was introduced from the `1.1.10` baseline, and subsequent `v1.3.x` releases are cut from `main`.
 
 This structure preserves pre-v4 API compatibility, keeps release ownership clear for maintainers, and allows current development to continue on the post-v4 line.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,18 @@ Alternatively, you can use `packer plugins install` to manage installation of th
 $ packer plugins install github.com/nutanix-cloud-native/nutanix
 ```
 
+### Release Branches and Version Lineage
+
+This plugin currently has two maintained release lines:
+
+- `release-1.2`: clean cut before the v4 API migration.
+- `main`: post-v4 API migration changes and the latest line.
+
+Going forward, release tags are created from the corresponding branch lines:
+
+- `v1.2.x` tags from `release-1.2` (pre-v4 API).
+- `v1.3.x` tags from `main` (post-v4 API, latest line).
+
 ### Components
 
 #### Builders


### PR DESCRIPTION
This PR adds documentation describing the release branch strategy and version lineage for the project.

Changes:
Add a Release Branches and Version Lineage section to README.md and docs/README.md.
Clarify that the v1.2.x release line is created from the release-1.2 branch, which is based on the pre-v4 API codebase.
Clarify that the v1.3.x release line is created from main and contains the post-v4 API changes.
Document the relationship between the release branches and version tags to make the release process clearer for future maintainers.

Background
The v1.2.x release line is based on the v1.1.4 tag, which represents the pre-v4 API baseline. This release stream is intended for maintenance releases (such as CVE fixes) without introducing the v4 API changes, while v1.3.x continues development from main.
